### PR TITLE
Config for text email number fields

### DIFF
--- a/notebooks/FAIMS3-Beta-Demo-Notebook.json
+++ b/notebooks/FAIMS3-Beta-Demo-Notebook.json
@@ -487,7 +487,9 @@
           "InputLabelProps": {
             "label": "Controlled Number"
           },
-          "InputProps": {},
+          "InputProps": {
+            "type": "number"
+          },
           "SelectProps": {},
           "fullWidth": true,
           "helperText": "This number must be at least 10 and not more than 20. ",

--- a/src/components/Fields/TextFieldEditor.tsx
+++ b/src/components/Fields/TextFieldEditor.tsx
@@ -1,0 +1,54 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { Grid, TextField } from "@mui/material";
+import { useAppSelector, useAppDispatch } from "../../state/hooks";
+import { BaseFieldEditor } from "./BaseFieldEditor";
+
+export const TextFieldEditor = ({ fieldName }: any) => {
+    const field = useAppSelector(state => state['ui-specification'].fields[fieldName]);
+    const dispatch = useAppDispatch();
+
+    const initVal = field['initialValue']
+
+    // const updateRows = (value: number) => {
+    //     const newField = JSON.parse(JSON.stringify(field)); // deep copy
+    //     newField['component-parameters'].InputProps.rows = value;
+    //     dispatch({ type: 'ui-specification/fieldUpdated', payload: { fieldName, newField } })
+    // }
+
+    const updateDefault = (value: string) => {
+        const newField = JSON.parse(JSON.stringify(field));
+        newField['initialValue'] = value;
+        dispatch({ type: 'ui-specification/fieldUpdated', payload: { fieldName, newField } })
+    }
+
+    return (
+        <BaseFieldEditor fieldName={fieldName}>
+            {/* only show this config if we want a prepop text field */}
+            {(field['component-parameters'].id === 'text-field-prepop') &&
+                <Grid item sm={6} xs={12}>
+                    <TextField
+                        name="prepopulated"
+                        variant="outlined"
+                        label="Default Text"
+                        value={initVal}
+                        helperText="Choose this field's default."
+                        onChange={(e) => { updateDefault(e.target.value) }}
+                    />
+                </Grid>
+            }
+        </BaseFieldEditor>
+    )
+};

--- a/src/components/Fields/TextFieldEditor.tsx
+++ b/src/components/Fields/TextFieldEditor.tsx
@@ -22,15 +22,32 @@ export const TextFieldEditor = ({ fieldName }: any) => {
 
     const initVal = field['initialValue']
 
-    // const updateRows = (value: number) => {
-    //     const newField = JSON.parse(JSON.stringify(field)); // deep copy
-    //     newField['component-parameters'].InputProps.rows = value;
-    //     dispatch({ type: 'ui-specification/fieldUpdated', payload: { fieldName, newField } })
-    // }
-
     const updateDefault = (value: string) => {
         const newField = JSON.parse(JSON.stringify(field));
         newField['initialValue'] = value;
+        dispatch({ type: 'ui-specification/fieldUpdated', payload: { fieldName, newField } })
+    }
+
+    const updateMinControl = (value: number) => {
+        const newField = JSON.parse(JSON.stringify(field));
+        newField['validationSchema'][1][1] = value;
+
+        console.log('hi ', field['component-parameters'].id)
+        if (field['component-parameters'].id === 'controlled-number') {
+            newField['validationSchema'][1][2] = "Must be " + value + " or more"
+        }
+
+        dispatch({ type: 'ui-specification/fieldUpdated', payload: { fieldName, newField } })
+    }
+
+    const updateMaxControl = (value: number) => {
+        const newField = JSON.parse(JSON.stringify(field));
+        newField['validationSchema'][2][1] = value;
+
+        if (field['component-parameters'].id === 'controlled-number') {
+            newField['validationSchema'][2][2] = "Must be " + value + " or less"
+        }
+
         dispatch({ type: 'ui-specification/fieldUpdated', payload: { fieldName, newField } })
     }
 
@@ -48,6 +65,31 @@ export const TextFieldEditor = ({ fieldName }: any) => {
                         onChange={(e) => { updateDefault(e.target.value) }}
                     />
                 </Grid>
+            }
+
+            {(field['component-parameters'].id === 'controlled-number' || field['component-parameters'].id === 'number-field-val') &&
+                <>
+                    <Grid item sm={6}>
+                        <TextField
+                            name="min"
+                            variant="outlined"
+                            label="Min Control"
+                            type="number"
+                            helperText="What is the min this number must be?"
+                            onChange={(e) => { updateMinControl(parseInt(e.target.value)) }}
+                        />
+                    </Grid>
+                    <Grid item sm={6}>
+                        <TextField
+                            name="controlled-number"
+                            variant="outlined"
+                            label="Max Control"
+                            type="number"
+                            helperText="What is the max this number can be?"
+                            onChange={(e) => { updateMaxControl(parseInt(e.target.value)) }}
+                        />
+                    </Grid>
+                </>
             }
         </BaseFieldEditor>
     )

--- a/src/components/field-editor.tsx
+++ b/src/components/field-editor.tsx
@@ -17,6 +17,7 @@ import { MultipleTextFieldEditor } from "./Fields/MultipleTextField";
 import { BaseFieldEditor } from "./Fields/BaseFieldEditor";
 import { TakePhotoFieldEditor } from "./Fields/TakePhotoField";
 import { SelectFieldEditor } from "./Fields/SelectField";
+import { TextFieldEditor } from "./Fields/TextFieldEditor";
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import { useAppSelector } from "../state/hooks";
 
@@ -44,6 +45,8 @@ export const FieldEditor = ({fieldName}) => {
                 (fieldComponent === 'TakePhoto' && <TakePhotoFieldEditor fieldName={fieldName}  />)
                 ||
                 (fieldComponent === 'Select' && <SelectFieldEditor fieldName={fieldName} />)
+                ||
+                (fieldComponent === 'TextField' && <TextFieldEditor fieldName={fieldName} />)
                 ||
                 <BaseFieldEditor
                     fieldName={fieldName} 

--- a/src/fields.tsx
+++ b/src/fields.tsx
@@ -35,6 +35,69 @@ const fields = {
       validationSchema: [['yup.string']],
       initialValue: '',
     },
+    'Email': {
+      'component-namespace': 'formik-material-ui', 
+      'component-name': 'TextField',
+      'type-returned': 'faims-core::Email', 
+      'component-parameters': {
+        fullWidth: true,
+        helperText: 'We can also store Email addresses.',
+        variant: 'outlined',
+        required: false,
+        InputProps: {
+          type: 'email', 
+        },
+        SelectProps: {},
+        InputLabelProps: {
+          label: 'Email',
+        },
+        FormHelperTextProps: {},
+      },
+      validationSchema: [['yup.string'], ['yup.email', 'Enter a valid email']],
+      initialValue: '',
+    },
+    'Number': {
+      'component-namespace': 'formik-material-ui', 
+      'component-name': 'TextField',
+      'type-returned': 'faims-core::Integer', 
+      'component-parameters': {
+        fullWidth: true,
+        helperText: 'We have fields for storing Numbers.',
+        variant: 'outlined',
+        required: false,
+        InputProps: {
+          type: 'number', 
+        },
+        SelectProps: {},
+        InputLabelProps: {
+          label: 'Number field',
+        },
+        FormHelperTextProps: {},
+      },
+      validationSchema: [['yup.number']],
+      initialValue: '',
+    },
+    'ControlledNumber': {
+      'component-namespace': 'formik-material-ui', 
+      'component-name': 'TextField',
+      'type-returned': 'faims-core::Integer', 
+      'component-parameters': {
+        fullWidth: true,
+        helperText: 'This number must be at least 10 and not more than 20.',
+        variant: 'outlined',
+        required: true,
+        InputProps: {
+          type: 'number', 
+        },
+        SelectProps: {},
+        InputLabelProps: {
+          label: 'Controlled number',
+        },
+        FormHelperTextProps: {},
+      },
+      validationSchema: [['yup.number'], ['yup.min', 10, 'Must be 10 or more'], ['yup.max', 20, 'Must be 20 or less'], ['yup.required', 'You must fill this in!']],
+      initialValue: '',
+    },
     'ActionButton': {
         'component-namespace': 'faims-custom', 
         'component-name': 'ActionButton',


### PR DESCRIPTION
### Issues #4 + #5.

#### Summary  
This should take care of the following field options as found in `FAIMS3-Beta-Demo-Notebook.json`:

- `controlled-number`
- `email` (is just the base in the sense that no extra configs are needed)
- `number-field` (is just the base in the sense that no extra configs are needed)
- `number-field-val` (this is the same as `controlled-number`, but slightly different)
- `required-text-field` (is just the base)
- `text-field` (is just the base)
- `text-field-prepop`

`controlled-text-field` has been parked. 