### PR TITLE
vertical stepper in form-editor

### DIFF
--- a/src/components/field-editor.tsx
+++ b/src/components/field-editor.tsx
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { Accordion, AccordionSummary, AccordionDetails } from "@mui/material";
+import { Accordion, AccordionSummary, AccordionDetails, Typography } from "@mui/material";
 import { MultipleTextFieldEditor } from "./Fields/MultipleTextField";
 import { BaseFieldEditor } from "./Fields/BaseFieldEditor";
 import { TakePhotoFieldEditor } from "./Fields/TakePhotoField";
@@ -35,7 +35,9 @@ export const FieldEditor = ({fieldName}) => {
 
     return (
         <Accordion key={fieldName}>
-            <AccordionSummary expandIcon={<ExpandMoreIcon />}>{getFieldLabel()} : {fieldComponent}</AccordionSummary>
+            <AccordionSummary expandIcon={<ExpandMoreIcon />}>
+                <Typography>{getFieldLabel()} : {fieldComponent}</Typography>
+            </AccordionSummary>
             <AccordionDetails>
                 {(fieldComponent === 'MultipleTextField' && 
                     <MultipleTextFieldEditor

--- a/src/components/form-editor.tsx
+++ b/src/components/form-editor.tsx
@@ -22,11 +22,11 @@ export const FormEditor = ({ viewSetId }) => {
 
     const viewSet = useAppSelector(state => state['ui-specification'].viewsets[viewSetId],
         (left, right) => {
-            console.log('CMP FormEditor', viewSetId, left, right, shallowEqual(left, right));
             return shallowEqual(left, right);
         });
     // const metadata = useAppSelector(state => state.metadata);
     //const dispatch = useAppDispatch();
+    const views = useAppSelector(state => state['ui-specification'].fviews);
 
     const [state, setState] = useState({
         inheritAccess: true,
@@ -134,44 +134,27 @@ export const FormEditor = ({ viewSetId }) => {
                 })} */}
 
                 <Box sx={{ width: '100%' }}>
-                    <Stepper nonLinear activeStep={activeStep} orientation="vertical">
+                    <Stepper nonLinear activeStep={activeStep} orientation="horizontal">
                         {viewSet.views.map((view: any, index: number) => (
                             <Step key={view}>
                                 <StepButton color="inherit" onClick={handleStep(index)}>
-                                    <Typography>{view}</Typography>
+                                    <Typography>{views[view].label}</Typography>
                                 </StepButton>
-                                <StepContent sx={{ mt: 1 }}>
-                                    <SectionEditor viewId={view} />
-                                    <Box sx={{ mt: 2 }}>
-                                        <div>
-                                            <Button
-                                                disabled={index === 0}
-                                                onClick={handleBack}
-                                                sx={{ mt: 1, mr: 1 }}
-                                            >
-                                                Back
-                                            </Button>
-                                            <Button
-                                                variant="contained"
-                                                onClick={handleNext}
-                                                sx={{ mt: 1, mr: 1 }}
-                                            >
-                                                {index === viewSet.views.length - 1 ? 'Finish' : 'Continue'}
-                                            </Button>
-                                        </div>
-                                    </Box>
-                                </StepContent>
                             </Step>
                         ))}
                     </Stepper>
-                    {activeStep === viewSet.views.length && (
+                    {activeStep === viewSet.views.length ? (
                         <Paper square elevation={0} sx={{ p: 3 }}>
                             <Alert severity="success">All steps completed - you're finished.</Alert>
                             <Button onClick={handleReset} sx={{ mt: 1, mr: 1 }}>
                                 Go back to the beginning
                             </Button>
                         </Paper>
-                    )}
+                    ) :
+                    (
+                        <SectionEditor viewId={viewSet.views[activeStep]} />
+                    )
+                }
                 </Box>
 
             </Grid>

--- a/src/components/form-editor.tsx
+++ b/src/components/form-editor.tsx
@@ -128,12 +128,8 @@ export const FormEditor = ({ viewSetId }) => {
             </Grid>
 
             <Grid item xs={12}>
-                {/* {viewSet.views.map((view: any, index) => {
-                    // Each fView defines a Page in the form
-                    // return (<SectionEditor key={view} viewId={view} />)
-                })} */}
-
-                <Box sx={{ width: '100%' }}>
+                <Grid container spacing={2}>
+                    <Grid item xs={12}>
                     <Stepper nonLinear activeStep={activeStep} orientation="horizontal">
                         {viewSet.views.map((view: any, index: number) => (
                             <Step key={view}>
@@ -143,6 +139,8 @@ export const FormEditor = ({ viewSetId }) => {
                             </Step>
                         ))}
                     </Stepper>
+                    </Grid>
+                    <Grid item xs={12}>
                     {activeStep === viewSet.views.length ? (
                         <Paper square elevation={0} sx={{ p: 3 }}>
                             <Alert severity="success">All steps completed - you're finished.</Alert>
@@ -154,9 +152,9 @@ export const FormEditor = ({ viewSetId }) => {
                     (
                         <SectionEditor viewId={viewSet.views[activeStep]} />
                     )
-                }
-                </Box>
-
+                    }
+                    </Grid>
+                </Grid>
             </Grid>
         </Grid>
     );

--- a/src/components/form-editor.tsx
+++ b/src/components/form-editor.tsx
@@ -12,20 +12,20 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { Grid, Paper, Alert, FormControlLabel, Checkbox, FormControl, InputLabel, Select, MenuItem } from "@mui/material";
+import { Grid, Paper, Alert, FormControlLabel, Checkbox, FormControl, InputLabel, Select, MenuItem, Box, Stepper, Typography, Step, Button, StepButton, StepContent } from "@mui/material";
 import { useAppSelector, useAppDispatch } from "../state/hooks";
 import { SectionEditor } from "./section-editor";
 import { useState } from "react";
 import { shallowEqual } from "react-redux";
 
-export const FormEditor = ({viewSetId}) => {
+export const FormEditor = ({ viewSetId }) => {
 
-    const viewSet = useAppSelector(state => state['ui-specification'].viewsets[viewSetId], 
-                                    (left, right) => {
-                                        console.log('CMP FormEditor', viewSetId, left, right, shallowEqual(left, right));
-                                        return shallowEqual(left, right);
-                                    });
-   // const metadata = useAppSelector(state => state.metadata);
+    const viewSet = useAppSelector(state => state['ui-specification'].viewsets[viewSetId],
+        (left, right) => {
+            console.log('CMP FormEditor', viewSetId, left, right, shallowEqual(left, right));
+            return shallowEqual(left, right);
+        });
+    // const metadata = useAppSelector(state => state.metadata);
     //const dispatch = useAppDispatch();
 
     const [state, setState] = useState({
@@ -36,78 +36,145 @@ export const FormEditor = ({viewSetId}) => {
     })
 
     const updateProperty = (prop: string, value: any) => {
-        const newState = {...state, [prop]: value};
-        setState(newState); 
+        const newState = { ...state, [prop]: value };
+        setState(newState);
     };
-    
-    console.log('FormEditor' , viewSetId);
+
+    console.log('FormEditor', viewSetId);
+
+    const [activeStep, setActiveStep] = useState(0);
+
+    const handleNext = () => {
+        setActiveStep((prevActiveStep) => prevActiveStep + 1);
+    };
+
+    const handleBack = () => {
+        setActiveStep((prevActiveStep) => prevActiveStep - 1);
+    };
+
+    const handleReset = () => {
+        setActiveStep(0);
+    };
+
+    const handleStep = (step: number) => () => {
+        setActiveStep(step);
+    };
+
     return (
         <Grid container spacing={2}>
 
-        <Grid item xs={12}>
-        <Paper elevation={3}>
+            <Grid item xs={12}>
+                <Paper elevation={3}>
 
-            <Alert severity="info">Configure who can access this form.</Alert>
+                    <Alert severity="info">Configure who can access this form.</Alert>
 
-            <Grid container spacing={2}>
-                <Grid item sm={6}>
-                    <FormControlLabel required 
-                    control={<Checkbox 
-                                checked={state.inheritAccess}
-                                onChange={(e) => updateProperty('inheritAccess', e.target.checked)} 
-                                />} label="Inherit Access from Notebook" />
-                </Grid>
+                    <Grid container spacing={2}>
+                        <Grid item sm={6}>
+                            <FormControlLabel
+                                required
+                                sx={{ pl: 1.5 }}
+                                control={<Checkbox
+                                    checked={state.inheritAccess}
+                                    onChange={(e) => updateProperty('inheritAccess', e.target.checked)}
+                                />}
+                                label="Inherit Access from Notebook" />
+                        </Grid>
 
-                {!state.inheritAccess && 
-                (
-                    <Grid item sm={6}>
-                        <FormControl fullWidth>
-                            <InputLabel id="demo-simple-select-label">Roles with access</InputLabel>
-                            <Select 
-                            name="access" 
-                            multiple
-                            label="Roles with access"
-                            value={state.access}
-                            onChange={(e) => updateProperty('access', e.target.value)}
-                            >
-                            <MenuItem value="admin">Admin</MenuItem>
-                            <MenuItem value="team">Team</MenuItem>
-                        </Select>
-                        </FormControl>
+                        {!state.inheritAccess &&
+                            (
+                                <Grid item sm={6}>
+                                    <FormControl fullWidth>
+                                        <InputLabel id="demo-simple-select-label">Roles with access</InputLabel>
+                                        <Select
+                                            name="access"
+                                            multiple
+                                            label="Roles with access"
+                                            value={state.access}
+                                            onChange={(e) => updateProperty('access', e.target.value)}
+                                        >
+                                            <MenuItem value="admin">Admin</MenuItem>
+                                            <MenuItem value="team">Team</MenuItem>
+                                        </Select>
+                                    </FormControl>
+                                </Grid>
+                            )
+                        }
                     </Grid>
-                )
-                }
-            </Grid>
 
-            <Alert severity="info">Configure annotation and uncertainty options 
-                                for all fields in this form.</Alert>
-            <Grid container spacing={2}>
+                    <Alert severity="info">Configure annotation and uncertainty options
+                        for all fields in this form.</Alert>
+                    <Grid container spacing={2}>
 
-                    <Grid item sm={6}>
-                        <FormControlLabel required 
-                        control={<Checkbox 
+                        <Grid item sm={6}>
+                            <FormControlLabel
+                                required
+                                sx={{ pl: 1.5 }}
+                                control={<Checkbox
                                     checked={state.annotation}
-                                    onChange={(e) => updateProperty('annotation', e.target.checked)} 
-                                    />} label="Enable Annotation" />
-                    </Grid>
+                                    onChange={(e) => updateProperty('annotation', e.target.checked)}
+                                />} 
+                                label="Enable Annotation" />
+                        </Grid>
 
-                    <Grid item sm={6}>
-                        <FormControlLabel required 
-                        control={<Checkbox 
+                        <Grid item sm={6}>
+                            <FormControlLabel required
+                                control={<Checkbox
                                     checked={state.uncertainty}
-                                    onChange={(e) => updateProperty('uncertainty', e.target.checked)} 
-                                    />} label="Enable Uncertainty" />
-                </Grid>
+                                    onChange={(e) => updateProperty('uncertainty', e.target.checked)}
+                                />} label="Enable Uncertainty" />
+                        </Grid>
+                    </Grid>
+                </Paper>
             </Grid>
-        </Paper>
-        </Grid>
 
-        <Grid item xs={12}>
-        {viewSet.views.map((view: any) => {
-            // Each fView defines a Page in the form
-            return (<SectionEditor key={view} viewId={view} />)
-        })}
-        </Grid>
+            <Grid item xs={12}>
+                {/* {viewSet.views.map((view: any, index) => {
+                    // Each fView defines a Page in the form
+                    // return (<SectionEditor key={view} viewId={view} />)
+                })} */}
+
+                <Box sx={{ width: '100%' }}>
+                    <Stepper nonLinear activeStep={activeStep} orientation="vertical">
+                        {viewSet.views.map((view: any, index: number) => (
+                            <Step key={view}>
+                                <StepButton color="inherit" onClick={handleStep(index)}>
+                                    <Typography>{view}</Typography>
+                                </StepButton>
+                                <StepContent sx={{ mt: 1 }}>
+                                    <SectionEditor viewId={view} />
+                                    <Box sx={{ mt: 2 }}>
+                                        <div>
+                                            <Button
+                                                disabled={index === 0}
+                                                onClick={handleBack}
+                                                sx={{ mt: 1, mr: 1 }}
+                                            >
+                                                Back
+                                            </Button>
+                                            <Button
+                                                variant="contained"
+                                                onClick={handleNext}
+                                                sx={{ mt: 1, mr: 1 }}
+                                            >
+                                                {index === viewSet.views.length - 1 ? 'Finish' : 'Continue'}
+                                            </Button>
+                                        </div>
+                                    </Box>
+                                </StepContent>
+                            </Step>
+                        ))}
+                    </Stepper>
+                    {activeStep === viewSet.views.length && (
+                        <Paper square elevation={0} sx={{ p: 3 }}>
+                            <Alert severity="success">All steps completed - you're finished.</Alert>
+                            <Button onClick={handleReset} sx={{ mt: 1, mr: 1 }}>
+                                Go back to the beginning
+                            </Button>
+                        </Paper>
+                    )}
+                </Box>
+
+            </Grid>
         </Grid>
     );
 }

--- a/src/components/section-editor.tsx
+++ b/src/components/section-editor.tsx
@@ -24,7 +24,7 @@ export const SectionEditor = ({ viewId }) => {
 
     const fView = useAppSelector(state => state['ui-specification'].fviews[viewId]);
     // const metadata = useAppSelector(state => state.metadata);
-    // const dispatch = useAppDispatch();
+    const dispatch = useAppDispatch();
 
     // roles that can be used to access this form
     const roles = useAppSelector(state => state.metadata.accesses, shallowEqual) as string[];
@@ -35,78 +35,69 @@ export const SectionEditor = ({ viewId }) => {
         label: fView.label
     })
 
-    useEffect(() => {
-        setState({
-            inheritAccess: true,
-            access: ['admin'],
-            label: fView.label
-        });
-    }, [fView]);
-
     const updateProperty = (prop: string, value: any) => {
         const newState = { ...state, [prop]: value };
         setState(newState);
     };
 
+    const updateSectionLabel = (label: string) => {
+        dispatch({type: 'ui-specification/sectionNameUpdated', payload: {viewId, label}});
+    }   
+
     console.log('SectionEditor', viewId);
 
     return (
         <>
-    
-                <Grid container spacing={2}>
-
-                    <Grid item sm={12}>
-                    <Typography variant='h3'>Section: {state.label}</Typography>
-                    </Grid>
-                    <Grid item sm={6} p={2}>
-                        <TextField
-                            fullWidth
-                            required
-                            label="Page Name"
-                            helperText="Name for this page of the form."
-                            name="label"
-                            data-testid="label"
-                            value={state.label}
-                            onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
-                                updateProperty('label', event.target.value);
-                            }}
-                        />
-                    </Grid>
-
-                    <Grid item sm={6}>
-                        <FormControlLabel required
-                            control={<Checkbox
-                                checked={state.inheritAccess}
-                                onChange={(e) => updateProperty('inheritAccess', e.target.checked)}
-                            />} label="Inherit Access from Form" />
-                    </Grid>
-
-                    {!state.inheritAccess &&
-                        (
-                            <Grid item sm={6}>
-                                <FormControl fullWidth>
-                                    <InputLabel id="demo-simple-select-label">Roles with access</InputLabel>
-                                    <Select
-                                        name="access"
-                                        multiple
-                                        label="Roles with access"
-                                        value={state.access}
-                                        onChange={(e) => updateProperty('access', e.target.value)}
-                                    >
-                                        {roles.map((role: string, index: number) => {
-                                            return (
-                                                <MenuItem key={index} value={role}>{role}</MenuItem>
-                                            )
-                                        })}
-                                    </Select>
-                                </FormControl>
-                            </Grid>
-                        )
-                    }
+            <Grid container spacing={2}>
+                <Grid item sm={6} p={2}>
+                    <TextField
+                        fullWidth
+                        required
+                        label="Page Name"
+                        helperText="Name for this page of the form."
+                        name="label"
+                        data-testid="label"
+                        value={fView.label}
+                        onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
+                            updateSectionLabel(event.target.value);
+                        }}
+                    />
                 </Grid>
 
+                <Grid item sm={6}>
+                    <FormControlLabel required
+                        control={<Checkbox
+                            checked={state.inheritAccess}
+                            onChange={(e) => updateProperty('inheritAccess', e.target.checked)}
+                        />} label="Inherit Access from Form" />
+                </Grid>
 
-                <FieldList viewId={viewId} />
-            </>
+                {!state.inheritAccess &&
+                    (
+                        <Grid item sm={6}>
+                            <FormControl fullWidth>
+                                <InputLabel id="demo-simple-select-label">Roles with access</InputLabel>
+                                <Select
+                                    name="access"
+                                    multiple
+                                    label="Roles with access"
+                                    value={state.access}
+                                    onChange={(e) => updateProperty('access', e.target.value)}
+                                >
+                                    {roles.map((role: string, index: number) => {
+                                        return (
+                                            <MenuItem key={index} value={role}>{role}</MenuItem>
+                                        )
+                                    })}
+                                </Select>
+                            </FormControl>
+                        </Grid>
+                    )
+                }
+            </Grid>
+
+
+            <FieldList viewId={viewId} />
+        </>
     );
 }

--- a/src/components/section-editor.tsx
+++ b/src/components/section-editor.tsx
@@ -16,15 +16,15 @@ import { Accordion, AccordionDetails, AccordionSummary, Checkbox, FormControl, F
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 
 import { FieldList } from "./field-list";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useAppSelector, useAppDispatch } from "../state/hooks";
 import { shallowEqual } from "react-redux";
 
 export const SectionEditor = ({ viewId }) => {
 
     const fView = useAppSelector(state => state['ui-specification'].fviews[viewId]);
-    const metadata = useAppSelector(state => state.metadata);
-    const dispatch = useAppDispatch();
+    // const metadata = useAppSelector(state => state.metadata);
+    // const dispatch = useAppDispatch();
 
     // roles that can be used to access this form
     const roles = useAppSelector(state => state.metadata.accesses, shallowEqual) as string[];
@@ -35,6 +35,14 @@ export const SectionEditor = ({ viewId }) => {
         label: fView.label
     })
 
+    useEffect(() => {
+        setState({
+            inheritAccess: true,
+            access: ['admin'],
+            label: fView.label
+        });
+    }, [fView]);
+
     const updateProperty = (prop: string, value: any) => {
         const newState = { ...state, [prop]: value };
         setState(newState);
@@ -43,12 +51,13 @@ export const SectionEditor = ({ viewId }) => {
     console.log('SectionEditor', viewId);
 
     return (
-        <Accordion>
-            <AccordionSummary expandIcon={<ExpandMoreIcon />}><Typography>Section: {state.label}</Typography></AccordionSummary>
-            <AccordionDetails>
-
+        <>
+    
                 <Grid container spacing={2}>
 
+                    <Grid item sm={12}>
+                    <Typography variant='h3'>Section: {state.label}</Typography>
+                    </Grid>
                     <Grid item sm={6} p={2}>
                         <TextField
                             fullWidth
@@ -98,7 +107,6 @@ export const SectionEditor = ({ viewId }) => {
 
 
                 <FieldList viewId={viewId} />
-            </AccordionDetails>
-        </Accordion>
+            </>
     );
 }

--- a/src/components/section-editor.tsx
+++ b/src/components/section-editor.tsx
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { Accordion, AccordionDetails, AccordionSummary, Checkbox, FormControl, FormControlLabel, Grid, InputLabel, MenuItem, Select, TextField } from "@mui/material";
+import { Accordion, AccordionDetails, AccordionSummary, Checkbox, FormControl, FormControlLabel, Grid, InputLabel, MenuItem, Select, TextField, Typography } from "@mui/material";
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 
 import { FieldList } from "./field-list";
@@ -20,7 +20,7 @@ import { useState } from "react";
 import { useAppSelector, useAppDispatch } from "../state/hooks";
 import { shallowEqual } from "react-redux";
 
-export const SectionEditor = ({viewId}) => {
+export const SectionEditor = ({ viewId }) => {
 
     const fView = useAppSelector(state => state['ui-specification'].fviews[viewId]);
     const metadata = useAppSelector(state => state.metadata);
@@ -28,7 +28,7 @@ export const SectionEditor = ({viewId}) => {
 
     // roles that can be used to access this form
     const roles = useAppSelector(state => state.metadata.accesses, shallowEqual) as string[];
- 
+
     const [state, setState] = useState({
         inheritAccess: true,
         access: ['admin'],
@@ -36,69 +36,69 @@ export const SectionEditor = ({viewId}) => {
     })
 
     const updateProperty = (prop: string, value: any) => {
-        const newState = {...state, [prop]: value};
-        setState(newState); 
+        const newState = { ...state, [prop]: value };
+        setState(newState);
     };
 
     console.log('SectionEditor', viewId);
 
     return (
-    <Accordion>
-        <AccordionSummary expandIcon={<ExpandMoreIcon />}>Section: {state.label}</AccordionSummary>
-        <AccordionDetails>
+        <Accordion>
+            <AccordionSummary expandIcon={<ExpandMoreIcon />}><Typography>Section: {state.label}</Typography></AccordionSummary>
+            <AccordionDetails>
 
-        <Grid container spacing={2}>
+                <Grid container spacing={2}>
 
-            <Grid item sm={6}>
-                <TextField
-                    fullWidth
-                    required
-                    label="Page Name"
-                    helperText="Name for this page of the form"
-                    name="label"
-                    data-testid="label"
-                    value={state.label}
-                    onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
-                        updateProperty('label', event.target.value);
-                    }}
-                />
-            </Grid>
-
-            <Grid item sm={6}>
-                <FormControlLabel required 
-                control={<Checkbox 
-                            checked={state.inheritAccess}
-                            onChange={(e) => updateProperty('inheritAccess', e.target.checked)} 
-                            />} label="Inherit Access from Form" />
-            </Grid>
-
-                {!state.inheritAccess && 
-                (
-                    <Grid item sm={6}>
-                        <FormControl fullWidth>
-                            <InputLabel id="demo-simple-select-label">Roles with access</InputLabel>
-                            <Select 
-                            name="access" 
-                            multiple
-                            label="Roles with access"
-                            value={state.access}
-                            onChange={(e) => updateProperty('access', e.target.value)}
-                            >
-                                {roles.map((role: string, index: number) => {
-                                    return (
-                                        <MenuItem key={index} value={role}>{role}</MenuItem>
-                                    )
-                                })}
-                        </Select>
-                        </FormControl>
+                    <Grid item sm={6} p={2}>
+                        <TextField
+                            fullWidth
+                            required
+                            label="Page Name"
+                            helperText="Name for this page of the form."
+                            name="label"
+                            data-testid="label"
+                            value={state.label}
+                            onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
+                                updateProperty('label', event.target.value);
+                            }}
+                        />
                     </Grid>
-                )
-                }
-            </Grid>
+
+                    <Grid item sm={6}>
+                        <FormControlLabel required
+                            control={<Checkbox
+                                checked={state.inheritAccess}
+                                onChange={(e) => updateProperty('inheritAccess', e.target.checked)}
+                            />} label="Inherit Access from Form" />
+                    </Grid>
+
+                    {!state.inheritAccess &&
+                        (
+                            <Grid item sm={6}>
+                                <FormControl fullWidth>
+                                    <InputLabel id="demo-simple-select-label">Roles with access</InputLabel>
+                                    <Select
+                                        name="access"
+                                        multiple
+                                        label="Roles with access"
+                                        value={state.access}
+                                        onChange={(e) => updateProperty('access', e.target.value)}
+                                    >
+                                        {roles.map((role: string, index: number) => {
+                                            return (
+                                                <MenuItem key={index} value={role}>{role}</MenuItem>
+                                            )
+                                        })}
+                                    </Select>
+                                </FormControl>
+                            </Grid>
+                        )
+                    }
+                </Grid>
 
 
-            <FieldList viewId={viewId} />
-        </AccordionDetails>
-    </Accordion>
+                <FieldList viewId={viewId} />
+            </AccordionDetails>
+        </Accordion>
     );
 }

--- a/src/state/uiSpec-reducer.ts
+++ b/src/state/uiSpec-reducer.ts
@@ -15,6 +15,7 @@
 import { PayloadAction, createSlice } from "@reduxjs/toolkit";
 import { NotebookUISpec, initialState } from "./initial";
 import { getFieldSpec } from "../fields";
+import { StaticDatePicker } from "@mui/lab";
 
 
 /**
@@ -51,6 +52,16 @@ export const uiSpecificationReducer = createSlice({
         loaded: (state: NotebookUISpec, action: PayloadAction<NotebookUISpec>) => {
             return action.payload;
         },
+        sectionNameUpdated: (state: NotebookUISpec,
+            action : PayloadAction<{viewId: string, label: string}>) => {
+                const { viewId, label } = action.payload;
+                console.log('updating section name', viewId, 'with', label);
+                if (viewId in state.fviews) {
+                    state.fviews[viewId].label = label;
+                } else {
+                    throw new Error(`Can't update unknown section ${viewId} via sectionNameUpdated action`);
+                }
+            },
         fieldUpdated: (state: NotebookUISpec, 
                        action: PayloadAction<{fieldName: string, newField: any}>) => {
             const { fieldName, newField } = action.payload;


### PR DESCRIPTION
### Issue #8. 

#### Summary 
Changed the layout in `form-editor.tsx` such that a vertical stepper is implemented; this makes the page less cluttered. The reason for a vertical stepper is due to the use of the `<StepContent/>` MUI component, which is not designed to work for a horizontal stepper. 

Note regarding some of the changes in files: I use the shift+option+F key combination often to auto-format code, which also results in formatting changes in places I did not intend to touch. 