### PR TITLE
Config for date fields

### DIFF
--- a/src/components/Fields/DateTimeNowEditor.tsx
+++ b/src/components/Fields/DateTimeNowEditor.tsx
@@ -1,0 +1,48 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { Grid, FormHelperText, FormControlLabel, Checkbox } from "@mui/material";
+import { useAppSelector, useAppDispatch } from "../../state/hooks";
+import { BaseFieldEditor } from "./BaseFieldEditor";
+
+export const DateTimeNowEditor = ({ fieldName }: any) => {
+    const field = useAppSelector(state => state['ui-specification'].fields[fieldName]);
+    const dispatch = useAppDispatch();
+
+    const updateIsAutoPick = (value: boolean) => {
+        const newField = JSON.parse(JSON.stringify(field));
+        newField['component-parameters'].is_auto_pick = value;
+        dispatch({ type: 'ui-specification/fieldUpdated', payload: { fieldName, newField } })
+    }
+
+    return (
+        <BaseFieldEditor fieldName={fieldName}>
+            <Grid item sm={6} xs={12}>
+                <FormControlLabel
+                    required
+                    control={
+                        <Checkbox
+                            checked={field['component-parameters'].is_auto_pick}
+                            onChange={(e) => { updateIsAutoPick(e.target.checked) }}
+                        />
+                    }
+                    label="Time pre-populated"
+                />
+                <FormHelperText>
+                    When the record is first created, populate this field with the current datetime.
+                </FormHelperText>
+            </Grid>
+        </BaseFieldEditor>
+    )
+};

--- a/src/components/field-editor.tsx
+++ b/src/components/field-editor.tsx
@@ -13,15 +13,17 @@
 // limitations under the License.
 
 import { Accordion, AccordionSummary, AccordionDetails } from "@mui/material";
+import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
+import { useAppSelector } from "../state/hooks";
+
 import { MultipleTextFieldEditor } from "./Fields/MultipleTextField";
 import { BaseFieldEditor } from "./Fields/BaseFieldEditor";
 import { TakePhotoFieldEditor } from "./Fields/TakePhotoField";
 import { SelectFieldEditor } from "./Fields/SelectField";
 import { TextFieldEditor } from "./Fields/TextFieldEditor";
-import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
-import { useAppSelector } from "../state/hooks";
+import { DateTimeNowEditor } from "./Fields/DateTimeNowEditor";
 
-export const FieldEditor = ({fieldName}) => {
+export const FieldEditor = ({ fieldName }: any) => {
 
     const field = useAppSelector(state => state['ui-specification'].fields[fieldName]); 
 
@@ -47,6 +49,8 @@ export const FieldEditor = ({fieldName}) => {
                 (fieldComponent === 'Select' && <SelectFieldEditor fieldName={fieldName} />)
                 ||
                 (fieldComponent === 'TextField' && <TextFieldEditor fieldName={fieldName} />)
+                ||
+                (fieldComponent === 'DateTimeNow' && <DateTimeNowEditor fieldName={fieldName} />)
                 ||
                 <BaseFieldEditor
                     fieldName={fieldName} 

--- a/src/fields.tsx
+++ b/src/fields.tsx
@@ -190,6 +190,69 @@ const fields = {
       validationSchema: [['yup.string']],
       initialValue: '',
     },
+    'DatePicker': {
+      'component-namespace': 'formik-material-ui', 
+      'component-name': 'TextField',
+      'type-returned': 'faims-core::Date', 
+      'component-parameters': {
+        fullWidth: true,
+        helperText: 'We have a date picker with a calendar prompt.',
+        variant: 'outlined',
+        required: false,
+        InputProps: {
+          type: 'date', 
+        },
+        SelectProps: {},
+        InputLabelProps: {
+          label: 'Date picker',
+        },
+        FormHelperTextProps: {},
+      },
+      validationSchema: [['yup.string']],
+      initialValue: '',
+    },
+    'DateTimePicker': {
+      'component-namespace': 'formik-material-ui', 
+      'component-name': 'TextField',
+      'type-returned': 'faims-core::Datetime', 
+      'component-parameters': {
+        fullWidth: true,
+        helperText: 'And a calendar prompt with a timestamp.',
+        variant: 'outlined',
+        required: false,
+        InputProps: {
+          type: 'datetime-local', 
+        },
+        SelectProps: {},
+        InputLabelProps: {
+          label: 'Date and Time picker',
+        },
+        FormHelperTextProps: {},
+      },
+      validationSchema: [['yup.string']],
+      initialValue: '',
+    },
+    'MonthPicker': {
+      'component-namespace': 'formik-material-ui', 
+      'component-name': 'TextField',
+      'type-returned': 'faims-core::Date', 
+      'component-parameters': {
+        fullWidth: true,
+        helperText: 'And one to select just the month if that is all you need.',
+        variant: 'outlined',
+        required: false,
+        InputProps: {
+          type: 'month', 
+        },
+        SelectProps: {},
+        InputLabelProps: {
+          label: 'Month picker',
+        },
+        FormHelperTextProps: {},
+      },
+      validationSchema: [['yup.string']],
+      initialValue: '',
+    },
     'FileUploader': {
       'component-namespace': 'faims-custom', 
       'component-name': 'FileUploader',


### PR DESCRIPTION
### Issue #10
#### Summary
This should take care of the following field options as found in `FAIMS3-Beta-Demo-Notebook.json`:

- `date-picker` (is just the base in the sense that no extra configs are needed);
- `date-and-time-picker` (is just the base in the sense that no extra configs are needed);
- `month-picker` (is just the base in the sense that no extra configs are needed); and
- `date-and-time-now`.

Also created the DatePicker, DateTimePicker and MonthPicker prototypes to allow a user to add new fields of those types. 

A DateTimeNow prototype already existed; an editor did not. I created one which includes a checkbox (exactly like in the main FAIMS app) asking if the user wants to pre-populate this field with the current date and time. The checkbox updates the value for the `is_auto_pick` prop. 