### PR TITLE
Delete operations for forms and sections

### DIFF
--- a/src/components/form-editor.tsx
+++ b/src/components/form-editor.tsx
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { Grid, Paper, Alert, Stepper, Typography, Step, Button, StepButton, TextField } from "@mui/material";
+import { Grid, Paper, Alert, Stepper, Typography, Step, Button, StepButton, TextField, Dialog, DialogTitle, DialogActions, DialogContent, DialogContentText } from "@mui/material";
 import DeleteIcon from '@mui/icons-material/Delete';
 import { useAppDispatch, useAppSelector } from "../state/hooks";
 import { SectionEditor } from "./section-editor";
@@ -34,9 +34,15 @@ export const FormEditor = ({ viewSetId }: { viewSetId: string }) => {
     const [activeStep, setActiveStep] = useState(0);
     const [newSectionName, setNewSectionName] = useState('New Section');
     const [alertMessage, setAlertMessage] = useState('');
+    const [open, setOpen] = useState(false);
+    const [deleteAlertMessage, setDeleteAlertMessage] = useState('');
 
     const handleStep = (step: number) => () => {
         setActiveStep(step);
+    };
+
+    const handleClose = () => {
+        setOpen(false);
     };
 
     const addNewSection = () => {
@@ -49,11 +55,11 @@ export const FormEditor = ({ viewSetId }: { viewSetId: string }) => {
     }
 
     const deleteForm = () => {
-        console.log('viewsetviews', viewSet.views)
         try {
             dispatch({ type: 'ui-specification/viewSetDeleted', payload: { viewSetId: viewSetId } });
         } catch (error: unknown) {
-            error instanceof Error && setAlertMessage(error.message);
+            setOpen(true);
+            error instanceof Error && setDeleteAlertMessage(error.message);
         }
     }
 
@@ -62,7 +68,24 @@ export const FormEditor = ({ viewSetId }: { viewSetId: string }) => {
             <Button variant="text" color="secondary" startIcon={<DeleteIcon />} onClick={deleteForm}>
                 Delete this form
             </Button>
-            {alertMessage && <Alert severity="error">{alertMessage}</Alert>}
+            <Dialog
+                open={open}
+                onClose={handleClose}
+                aria-labelledby="alert-dialog-title"
+                aria-describedby="alert-dialog-description"
+            >
+                <DialogTitle id="alert-dialog-title">
+                    {"Form cannot be deleted."}
+                </DialogTitle>
+                <DialogContent>
+                    <DialogContentText id="alert-dialog-description">
+                        {deleteAlertMessage}
+                    </DialogContentText>
+                </DialogContent>
+                <DialogActions>
+                    <Button onClick={handleClose}>OK</Button>
+                </DialogActions>
+            </Dialog>
 
             <Grid item xs={12}>
                 <Grid container spacing={2}>

--- a/src/components/form-editor.tsx
+++ b/src/components/form-editor.tsx
@@ -61,11 +61,11 @@ export const FormEditor = ({ viewSetId }: { viewSetId: string }) => {
         setOpen(true);
         setPreventDeleteDialog(false);
         setDeleteAlertTitle("Are you sure you want to delete this form?");
-        setDeleteAlertMessage("You will lose all your progress.");
+        setDeleteAlertMessage("All fields in the form will also be deleted.");
     }
 
     const preventFormDelete = () => {
-        // we dont need the field names, only their values
+        // we don't need the field names, only their values
         const fieldValues = Object.values(fields)
         let flag: boolean = false;
         // search through all the values for mention of the form to be deleted in the related_type param
@@ -78,10 +78,10 @@ export const FormEditor = ({ viewSetId }: { viewSetId: string }) => {
 
                 // extracting where in the notebook the user has to look
                 const fviewsEntries = Object.entries(views)
-                fviewsEntries.map((fviewId, idx) => {
+                fviewsEntries.map((_viewId, idx) => {
                     // accessing the first element of the subarray only because it holds all the info
                     fviewsEntries[idx][1].fields.map((field) => {
-                        // finding the form+section relatedFieldname belongs to
+                        // finding the form+section relatedFieldName belongs to
                         if(field === relatedFieldName) {
                             // setting the dialog text here
                             setDeleteAlertTitle("Form cannot be deleted.");

--- a/src/components/form-editor.tsx
+++ b/src/components/form-editor.tsx
@@ -37,6 +37,8 @@ export const FormEditor = ({ viewSetId }: { viewSetId: string }) => {
     const [alertMessage, setAlertMessage] = useState('');
     const [open, setOpen] = useState(false);
     const [deleteAlertMessage, setDeleteAlertMessage] = useState('');
+    const [deleteAlertTitle, setDeleteAlertTitle] = useState('');
+    const [preventDeleteDialog, setPreventDeleteDialog] = useState(false);
 
     const handleStep = (step: number) => () => {
         setActiveStep(step);
@@ -53,6 +55,13 @@ export const FormEditor = ({ viewSetId }: { viewSetId: string }) => {
             error instanceof Error &&
                 setAlertMessage(error.message);
         }
+    }
+
+    const deleteConfirmation = () => {
+        setOpen(true);
+        setPreventDeleteDialog(false);
+        setDeleteAlertTitle("Are you sure you want to delete this form?");
+        setDeleteAlertMessage("You will lose all your progress.");
     }
 
     const preventFormDelete = () => {
@@ -72,17 +81,20 @@ export const FormEditor = ({ viewSetId }: { viewSetId: string }) => {
         // SANITY CHECK. Don't allow the user to delete the form if they've used it in a RelatedRecordSelector field
         if (preventFormDelete()) {
             setOpen(true);
+            setPreventDeleteDialog(true);
+            setDeleteAlertTitle("Form cannot be deleted.");
             setDeleteAlertMessage("This form is being referred to in a RelatedRecordSelector field. Please fix this and try again.");
         }
         else {
             dispatch({ type: 'ui-specification/viewSetDeleted', payload: { viewSetId: viewSetId } });
+            handleClose();
         }
     }
 
     return (
         <Grid container spacing={2}>
             <Grid item xs={12}>
-                <Button variant="text" color="secondary" startIcon={<DeleteIcon />} onClick={deleteForm}>
+                <Button variant="text" color="secondary" startIcon={<DeleteIcon />} onClick={deleteConfirmation}>
                     Delete this form
                 </Button>
                 <Dialog
@@ -92,16 +104,23 @@ export const FormEditor = ({ viewSetId }: { viewSetId: string }) => {
                     aria-describedby="alert-dialog-description"
                 >
                     <DialogTitle id="alert-dialog-title">
-                        {"Form cannot be deleted."}
+                        {deleteAlertTitle}
                     </DialogTitle>
                     <DialogContent>
                         <DialogContentText id="alert-dialog-description">
                             {deleteAlertMessage}
                         </DialogContentText>
                     </DialogContent>
-                    <DialogActions>
-                        <Button onClick={handleClose}>OK</Button>
-                    </DialogActions>
+                    {preventDeleteDialog ?
+                        <DialogActions>
+                            <Button onClick={handleClose}>OK</Button>
+                        </DialogActions>
+                        :
+                        <DialogActions>
+                            <Button onClick={deleteForm}>Yes</Button>
+                            <Button onClick={handleClose}>No</Button>
+                        </DialogActions>
+                    }
                 </Dialog>
             </Grid>
 

--- a/src/components/form-editor.tsx
+++ b/src/components/form-editor.tsx
@@ -31,7 +31,7 @@ export const FormEditor = ({ viewSetId }: { viewSetId: string }) => {
     const dispatch = useAppDispatch();
 
     console.log('FormEditor', viewSetId);
-
+    
     const [activeStep, setActiveStep] = useState(0);
     const [newSectionName, setNewSectionName] = useState('New Section');
     const [alertMessage, setAlertMessage] = useState('');
@@ -72,6 +72,23 @@ export const FormEditor = ({ viewSetId }: { viewSetId: string }) => {
         fieldValues.map((fieldValue) => {
             if (fieldValue["component-parameters"].related_type === viewSetId) {
                 flag = true;
+                
+                // extracting the name of the field to advise user
+                const relatedFieldName = fieldValue["component-parameters"].name;
+
+                // extracting where in the notebook the user has to look
+                const fviewsEntries = Object.entries(views)
+                fviewsEntries.map((fviewId, idx) => {
+                    // accessing the first element of the subarray only because it holds all the info
+                    fviewsEntries[idx][1].fields.map((field) => {
+                        // finding the form+section relatedFieldname belongs to
+                        if(field === relatedFieldName) {
+                            // setting the dialog text here
+                            setDeleteAlertTitle("Form cannot be deleted.");
+                            setDeleteAlertMessage("Please update the field, '"+relatedFieldName+"' found in "+fviewsEntries[idx][0]+", to remove the reference to allow this form to be deleted.");
+                        }
+                    })
+                })
             }
         })
         return flag;
@@ -82,8 +99,6 @@ export const FormEditor = ({ viewSetId }: { viewSetId: string }) => {
         if (preventFormDelete()) {
             setOpen(true);
             setPreventDeleteDialog(true);
-            setDeleteAlertTitle("Form cannot be deleted.");
-            setDeleteAlertMessage("This form is being referred to in a RelatedRecordSelector field. Please fix this and try again.");
         }
         else {
             dispatch({ type: 'ui-specification/viewSetDeleted', payload: { viewSetId: viewSetId } });
@@ -94,6 +109,7 @@ export const FormEditor = ({ viewSetId }: { viewSetId: string }) => {
     const deleteSection = (viewSetID: string, viewID: string) => {
         dispatch({ type: 'ui-specification/formSectionDeleted', payload: { viewSetID, viewID } });
 
+        // making sure the stepper jumps steps (forward or backward) intuitively 
         if (viewSet.views[viewSet.views.length-1] === viewID && viewSet.views.length > 1) {
             setActiveStep(activeStep-1)
         }
@@ -102,7 +118,7 @@ export const FormEditor = ({ viewSetId }: { viewSetId: string }) => {
     return (
         <Grid container spacing={2}>
             <Grid item xs={12}>
-                <Button variant="text" color="secondary" startIcon={<DeleteIcon />} onClick={deleteConfirmation}>
+                <Button variant="text" color="error" size="medium" startIcon={<DeleteIcon />} onClick={deleteConfirmation}>
                     Delete this form
                 </Button>
                 <Dialog

--- a/src/components/form-editor.tsx
+++ b/src/components/form-editor.tsx
@@ -91,6 +91,14 @@ export const FormEditor = ({ viewSetId }: { viewSetId: string }) => {
         }
     }
 
+    const deleteSection = (viewSetID: string, viewID: string) => {
+        dispatch({ type: 'ui-specification/formSectionDeleted', payload: { viewSetID, viewID } });
+
+        if (viewSet.views[viewSet.views.length-1] === viewID && viewSet.views.length > 1) {
+            setActiveStep(activeStep-1)
+        }
+    }
+
     return (
         <Grid container spacing={2}>
             <Grid item xs={12}>
@@ -144,7 +152,7 @@ export const FormEditor = ({ viewSetId }: { viewSetId: string }) => {
                             </Paper>
                         ) :
                             (
-                                <SectionEditor viewId={viewSet.views[activeStep]} viewSetId={viewSetId} />
+                                <SectionEditor viewSetId={viewSetId} viewId={viewSet.views[activeStep]} deleteCallback={deleteSection} />
                             )
                         }
                     </Grid>

--- a/src/components/form-editor.tsx
+++ b/src/components/form-editor.tsx
@@ -13,13 +13,14 @@
 // limitations under the License.
 
 import { Grid, Paper, Alert, Stepper, Typography, Step, Button, StepButton, TextField } from "@mui/material";
+import DeleteIcon from '@mui/icons-material/Delete';
 import { useAppDispatch, useAppSelector } from "../state/hooks";
 import { SectionEditor } from "./section-editor";
 import { useState } from "react";
 import { shallowEqual } from "react-redux";
 import { Notebook } from "../state/initial";
 
-export const FormEditor = ({ viewSetId }: {viewSetId: string}) => {
+export const FormEditor = ({ viewSetId }: { viewSetId: string }) => {
 
     const viewSet = useAppSelector((state: Notebook) => state['ui-specification'].viewsets[viewSetId],
         (left, right) => {
@@ -40,16 +41,29 @@ export const FormEditor = ({ viewSetId }: {viewSetId: string}) => {
 
     const addNewSection = () => {
         try {
-            dispatch({type: 'ui-specification/formSectionAdded', payload: {viewSetId: viewSetId, sectionLabel: newSectionName}});
+            dispatch({ type: 'ui-specification/formSectionAdded', payload: { viewSetId: viewSetId, sectionLabel: newSectionName } });
         } catch (error: unknown) {
             error instanceof Error &&
                 setAlertMessage(error.message);
         }
     }
 
+    const deleteForm = () => {
+        console.log('viewsetviews', viewSet.views)
+        try {
+            dispatch({ type: 'ui-specification/viewSetDeleted', payload: { viewSetId: viewSetId } });
+        } catch (error: unknown) {
+            error instanceof Error && setAlertMessage(error.message);
+        }
+    }
+
     return (
         <Grid container spacing={2}>
-  
+            <Button variant="text" color="secondary" startIcon={<DeleteIcon />} onClick={deleteForm}>
+                Delete this form
+            </Button>
+            {alertMessage && <Alert severity="error">{alertMessage}</Alert>}
+
             <Grid item xs={12}>
                 <Grid container spacing={2}>
                     <Grid item xs={12}>
@@ -66,7 +80,7 @@ export const FormEditor = ({ viewSetId }: {viewSetId: string}) => {
                     <Grid item xs={12}>
                         {activeStep === viewSet.views.length ? (
                             <Paper square elevation={0} sx={{ p: 3 }}>
-                                <Typography>Form has been created. No fields added yet.</Typography> 
+                                <Typography>Form has been created. No fields added yet.</Typography>
                             </Paper>
                         ) :
                             (

--- a/src/components/form-editor.tsx
+++ b/src/components/form-editor.tsx
@@ -140,7 +140,7 @@ export const FormEditor = ({ viewSetId }: { viewSetId: string }) => {
                     <Grid item xs={12}>
                         {activeStep === viewSet.views.length ? (
                             <Paper square elevation={0} sx={{ p: 3 }}>
-                                <Typography>Form has been created. No fields added yet.</Typography>
+                                <Typography>Form has been created. No sections or fields added yet.</Typography>
                             </Paper>
                         ) :
                             (

--- a/src/components/section-editor.tsx
+++ b/src/components/section-editor.tsx
@@ -22,10 +22,11 @@ import { useState } from "react";
 
 type Props = {
     viewSetId: string,
-    viewId: string
+    viewId: string,
+    deleteCallback: any,
 };
 
-export const SectionEditor = ({ viewSetId, viewId }: Props) => {
+export const SectionEditor = ({ viewSetId, viewId, deleteCallback }: Props) => {
 
     const fView = useAppSelector((state: Notebook) => state['ui-specification'].fviews[viewId]);
     const dispatch = useAppDispatch();
@@ -43,7 +44,7 @@ export const SectionEditor = ({ viewSetId, viewId }: Props) => {
     }
 
     const deleteSection = () => {
-        dispatch({ type: 'ui-specification/formSectionDeleted', payload: { viewSetId, viewId } });
+        deleteCallback(viewSetId, viewId)
         handleClose();
     }
 

--- a/src/components/section-editor.tsx
+++ b/src/components/section-editor.tsx
@@ -23,7 +23,7 @@ import { useState } from "react";
 type Props = {
     viewSetId: string,
     viewId: string,
-    deleteCallback: any,
+    deleteCallback: (viewSetID: string, viewID: string) => void,
 };
 
 export const SectionEditor = ({ viewSetId, viewId, deleteCallback }: Props) => {
@@ -66,7 +66,7 @@ export const SectionEditor = ({ viewSetId, viewId, deleteCallback }: Props) => {
                     />
                 </Grid>
                 <Grid item sm={6}>
-                    <Button variant="outlined" color="primary" size="small" startIcon={<DeleteIcon />} onClick={() => setOpen(true)}>
+                    <Button variant="text" color="error" size="small" startIcon={<DeleteIcon />} onClick={() => setOpen(true)}>
                         Delete this section
                     </Button>
                     <Dialog

--- a/src/components/section-editor.tsx
+++ b/src/components/section-editor.tsx
@@ -12,11 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {Grid, TextField } from "@mui/material";
+import { Grid, TextField, Button, Dialog, DialogActions, DialogTitle } from "@mui/material";
+import DeleteIcon from "@mui/icons-material/Delete";
 
 import { FieldList } from "./field-list";
-import { useAppSelector, useAppDispatch } from "../state/hooks"; 
+import { useAppSelector, useAppDispatch } from "../state/hooks";
 import { Notebook } from '../state/initial';
+import { useState } from "react";
 
 type Props = {
     viewSetId: string,
@@ -28,11 +30,22 @@ export const SectionEditor = ({ viewSetId, viewId }: Props) => {
     const fView = useAppSelector((state: Notebook) => state['ui-specification'].fviews[viewId]);
     const dispatch = useAppDispatch();
 
-    const updateSectionLabel = (label: string) => {
-        dispatch({type: 'ui-specification/sectionNameUpdated', payload: {viewId, label}});
-    }   
-
     console.log('SectionEditor', viewId);
+
+    const [open, setOpen] = useState(false);
+
+    const updateSectionLabel = (label: string) => {
+        dispatch({ type: 'ui-specification/sectionNameUpdated', payload: { viewId, label } });
+    }
+
+    const handleClose = () => {
+        setOpen(false);
+    }
+
+    const deleteSection = () => {
+        dispatch({ type: 'ui-specification/formSectionDeleted', payload: { viewSetId, viewId } });
+        handleClose();
+    }
 
     return (
         <>
@@ -51,10 +64,29 @@ export const SectionEditor = ({ viewSetId, viewId }: Props) => {
                         }}
                     />
                 </Grid>
+                <Grid item sm={6}>
+                    <Button variant="outlined" color="primary" size="small" startIcon={<DeleteIcon />} onClick={() => setOpen(true)}>
+                        Delete this section
+                    </Button>
+                    <Dialog
+                        open={open}
+                        onClose={handleClose}
+                        aria-labelledby="alert-dialog-title"
+                        aria-describedby="alert-dialog-description"
+                    >
+                        <DialogTitle id="alert-dialog-title">
+                            Are you sure you want to delete this section?
+                        </DialogTitle>
+                        <DialogActions>
+                            <Button onClick={deleteSection}>Yes</Button>
+                            <Button onClick={handleClose}>No</Button>
+                        </DialogActions>
+                    </Dialog>
+                </Grid>
             </Grid>
 
 
-            <FieldList viewId={viewId} viewSetId={viewSetId}/>
+            <FieldList viewId={viewId} viewSetId={viewSetId} />
         </>
     );
 }

--- a/src/state/uiSpec-reducer.ts
+++ b/src/state/uiSpec-reducer.ts
@@ -23,47 +23,47 @@ import { getFieldSpec } from "../fields";
  * @param str input string
  * @returns url safe version of the string
  * https://ourcodeworld.com/articles/read/255/creating-url-slugs-properly-in-javascript-including-transliteration-for-utf-8
- */
+*/
 export const slugify = (str: string) => {
     str = str.trim();
     //str = str.toLowerCase();
-  
+
     // remove accents, swap ñ for n, etc
     const from = 'ãàáäâáº½èéëêìíïîõòóöôùúüûñç·/_,:;';
     const to = 'aaaaaeeeeeiiiiooooouuuunc------';
     for (let i = 0, l = from.length; i < l; i++) {
-      str = str.replace(new RegExp(from.charAt(i), 'g'), to.charAt(i));
+        str = str.replace(new RegExp(from.charAt(i), 'g'), to.charAt(i));
     }
-  
+
     str = str
-      .replace(/[^A-Za-z0-9 -]/g, '') // remove invalid chars
-      .replace(/\s+/g, '-') // collapse whitespace and replace by -
-      .replace(/-+/g, '-'); // collapse dashes
-  
+        .replace(/[^A-Za-z0-9 -]/g, '') // remove invalid chars
+        .replace(/\s+/g, '-') // collapse whitespace and replace by -
+        .replace(/-+/g, '-'); // collapse dashes
+
     return str;
-  };
+};
 
 
 
 export const uiSpecificationReducer = createSlice({
     name: 'ui-specification',
-    initialState:  initialState["ui-specification"],
+    initialState: initialState["ui-specification"],
     reducers: {
         loaded: (_state: NotebookUISpec, action: PayloadAction<NotebookUISpec>) => {
             return action.payload;
         },
         sectionNameUpdated: (state: NotebookUISpec,
-            action : PayloadAction<{viewId: string, label: string}>) => {
-                const { viewId, label } = action.payload;
-                console.log('updating section name', viewId, 'with', label);
-                if (viewId in state.fviews) {
-                    state.fviews[viewId].label = label;
-                } else {
-                    throw new Error(`Can't update unknown section ${viewId} via sectionNameUpdated action`);
-                }
-            },
-        fieldUpdated: (state: NotebookUISpec, 
-                       action: PayloadAction<{fieldName: string, newField: FieldType}>) => {
+            action: PayloadAction<{ viewId: string, label: string }>) => {
+            const { viewId, label } = action.payload;
+            console.log('updating section name', viewId, 'with', label);
+            if (viewId in state.fviews) {
+                state.fviews[viewId].label = label;
+            } else {
+                throw new Error(`Can't update unknown section ${viewId} via sectionNameUpdated action`);
+            }
+        },
+        fieldUpdated: (state: NotebookUISpec,
+            action: PayloadAction<{ fieldName: string, newField: FieldType }>) => {
             const { fieldName, newField } = action.payload;
             console.log('updating field', fieldName, 'with', newField);
             if (fieldName in state.fields) {
@@ -73,7 +73,7 @@ export const uiSpecificationReducer = createSlice({
             }
         },
         fieldMoved: (state: NotebookUISpec,
-                     action: PayloadAction<{fieldName: string, viewId: string, direction: 'up' | 'down'}>) => {
+            action: PayloadAction<{ fieldName: string, viewId: string, direction: 'up' | 'down' }>) => {
 
             const { fieldName, viewId, direction } = action.payload;
             // this involves finding the field in the list of fields in the view
@@ -83,14 +83,14 @@ export const uiSpecificationReducer = createSlice({
                 if (fieldList[i] == fieldName) {
                     if (direction === 'up') {
                         if (i > 0) {
-                            const tmp = fieldList[i-1];
-                            fieldList[i-1] = fieldList[i];
+                            const tmp = fieldList[i - 1];
+                            fieldList[i - 1] = fieldList[i];
                             fieldList[i] = tmp;
                         }
                     } else {
                         if (i < fieldList.length - 1) {
-                            const tmp = fieldList[i+1];
-                            fieldList[i+1] = fieldList[i];
+                            const tmp = fieldList[i + 1];
+                            fieldList[i + 1] = fieldList[i];
                             fieldList[i] = tmp;
                         }
                     }
@@ -101,16 +101,16 @@ export const uiSpecificationReducer = createSlice({
             state.fviews[viewId].fields = fieldList;
         },
         fieldRenamed: (state: NotebookUISpec,
-            action: PayloadAction<{viewId: string, fieldName: string, newFieldName: string}>) => {
+            action: PayloadAction<{ viewId: string, fieldName: string, newFieldName: string }>) => {
 
-            const {viewId, fieldName, newFieldName} = action.payload;
+            const { viewId, fieldName, newFieldName } = action.payload;
             if (fieldName in state.fields) {
                 const field = state.fields[fieldName];
 
                 // ensure newFieldName is unique
                 let fieldLabel = slugify(newFieldName);
                 let N = 1;
-                while(fieldLabel in state.fields) { 
+                while (fieldLabel in state.fields) {
                     fieldLabel = slugify(fieldName + ' ' + N);
                     N += 1;
                 }
@@ -132,16 +132,16 @@ export const uiSpecificationReducer = createSlice({
                 throw new Error(`Cannot rename unknown field ${fieldName} via fieldRenamed action`);
             }
         },
-        fieldAdded: (state: NotebookUISpec, 
-                     action: PayloadAction<{
-                        fieldName: string, 
-                        fieldType: string, 
-                        viewId: string,
-                        viewSetId: string
-                    }>) => {
+        fieldAdded: (state: NotebookUISpec,
+            action: PayloadAction<{
+                fieldName: string,
+                fieldType: string,
+                viewId: string,
+                viewSetId: string
+            }>) => {
             const { fieldName, fieldType, viewId, viewSetId } = action.payload;
             console.log('adding field', fieldName, 'to', viewSetId, '-', viewId, 'type', fieldType);
-            
+
             const newField: FieldType = getFieldSpec(fieldType);
 
             let fieldLabel = slugify(fieldName);
@@ -184,15 +184,15 @@ export const uiSpecificationReducer = createSlice({
             // try to set the field label
             if (newField['component-parameters'] && 'label' in newField['component-parameters']) {
                 newField['component-parameters'].label = fieldName;
-            } else if ('InputLabelProps' in newField['component-parameters']  && 
-                        newField['component-parameters'].InputLabelProps &&
-                        'label' in newField['component-parameters'].InputLabelProps) {
+            } else if ('InputLabelProps' in newField['component-parameters'] &&
+                newField['component-parameters'].InputLabelProps &&
+                'label' in newField['component-parameters'].InputLabelProps) {
                 newField['component-parameters'].InputLabelProps.label = fieldName;
             }
 
             // ensure a unique field name
             let N = 1;
-            while(fieldLabel in state.fields) { 
+            while (fieldLabel in state.fields) {
                 fieldLabel = slugify(fieldName + ' ' + N);
                 N += 1;
             }
@@ -201,11 +201,11 @@ export const uiSpecificationReducer = createSlice({
             // add to fields and to the fview section
             state.fields[fieldLabel] = newField;
             state.fviews[viewId].fields.push(fieldLabel);
-        
+
         },
         fieldDeleted: (state: NotebookUISpec,
-                       action: PayloadAction<{fieldName: string, viewId: string}>) => {
-            const {fieldName, viewId} = action.payload;
+            action: PayloadAction<{ fieldName: string, viewId: string }>) => {
+            const { fieldName, viewId } = action.payload;
             // remove the field from fields and the viewSet
             if (fieldName in state.fields) {
                 delete state.fields[fieldName];
@@ -216,8 +216,8 @@ export const uiSpecificationReducer = createSlice({
             }
         },
         viewSetAdded: (state: NotebookUISpec,
-                       action: PayloadAction<{formName: string}>) => {
-            const {formName} = action.payload;
+            action: PayloadAction<{ formName: string }>) => {
+            const { formName } = action.payload;
             const newViewSet = {
                 label: formName,
                 views: []
@@ -231,9 +231,49 @@ export const uiSpecificationReducer = createSlice({
                 state.visible_types.push(formID);
             }
         },
+        viewSetDeleted: (state: NotebookUISpec, action: PayloadAction<{ viewSetId: string }>) => {
+            const { viewSetId } = action.payload;
+
+            if (viewSetId in state.viewsets) {
+                // working copy of the section names ('views') part of the form that is to be removed
+                const viewSetViews: string[] = state.viewsets[viewSetId].views
+                viewSetViews.map((view) => {
+                    if (view in state.fviews) {
+                        // working copy of the field names ('fields') part of the section that is part of the form that is to be removed
+                        const fviewFields: string[] = state.fviews[view].fields
+                        fviewFields.map((formField) => {
+                            if (formField in state.fields) {
+                                if (state.fields[formField]["component-parameters"].related_type === viewSetId) {
+                                    throw new Error(`This form is being used in a Relation Field. Therefore, you cannot delete it. Please fix this and try again.`)
+                                }
+                                else {
+                                    // remove the fields in 'fields' belonging to their respective sections in the form
+                                    delete state.fields[formField]
+                                }
+                            }
+                            else {
+                                throw new Error(`Cannot delete unknown field ${formField} via viewSetDeleted action`);
+                            }
+                        })
+                        // remove the sections in 'fviews' belonging to the form 
+                        delete state.fviews[view];
+                    }
+                    else {
+                        throw new Error(`Cannot delete unknown section ${view} via viewSetDeleted action`);
+                    }
+                })
+                // remove the form from 'viewsets' and 'visible_types'
+                delete state.viewsets[viewSetId];
+                const newVisibleTypes = state.visible_types.filter((field) => field !== viewSetId);
+                state.visible_types = newVisibleTypes;
+            }
+            else {
+                throw new Error(`Cannot delete unknown form ${viewSetId} via viewSetDeleted action`);
+            }
+        },
         formSectionAdded: (state: NotebookUISpec,
-            action: PayloadAction<{viewSetId: string, sectionLabel: string}>) => {
-            const {viewSetId, sectionLabel} = action.payload;
+            action: PayloadAction<{ viewSetId: string, sectionLabel: string }>) => {
+            const { viewSetId, sectionLabel } = action.payload;
             const sectionId = viewSetId + '-' + slugify(sectionLabel);
             const newSection = {
                 label: sectionLabel,

--- a/src/state/uiSpec-reducer.ts
+++ b/src/state/uiSpec-reducer.ts
@@ -243,8 +243,9 @@ export const uiSpecificationReducer = createSlice({
                         const fviewFields: string[] = state.fviews[view].fields
                         fviewFields.map((formField) => {
                             if (formField in state.fields) {
+                                // SANITY CHECK. Don't allow the user to delete the form if they've used it in a RelatedRecordSelector field
                                 if (state.fields[formField]["component-parameters"].related_type === viewSetId) {
-                                    throw new Error(`This form is being used in a Relation Field. Therefore, you cannot delete it. Please fix this and try again.`)
+                                    throw new Error(`This form is being used in a Relation Field. Please fix this and try again.`)
                                 }
                                 else {
                                     // remove the fields in 'fields' belonging to their respective sections in the form

--- a/src/state/uiSpec-reducer.ts
+++ b/src/state/uiSpec-reducer.ts
@@ -272,12 +272,12 @@ export const uiSpecificationReducer = createSlice({
                 state.viewsets[viewSetId].views.push(sectionId);
             }
         },
-        formSectionDeleted: (state: NotebookUISpec, action: PayloadAction<{ viewSetId: string, viewId: string }>) => {
-            const { viewSetId, viewId } = action.payload;
+        formSectionDeleted: (state: NotebookUISpec, action: PayloadAction<{ viewSetID: string, viewID: string }>) => {
+            const { viewSetID, viewID } = action.payload;
 
-            if (viewId in state.fviews) {
+            if (viewID in state.fviews) {
                 // working copy of the field names ('fields') part of the section that is to be removed
-                const sectionFields: string[] = state.fviews[viewId].fields
+                const sectionFields: string[] = state.fviews[viewID].fields
                 sectionFields.map((field) => {
                     if (field in state.fields) {
                         // remove the fields in 'fields' belonging to the section 
@@ -285,9 +285,9 @@ export const uiSpecificationReducer = createSlice({
                     }
                 })
                 // remove the section from 'fviews' & 'viewsets'
-                delete state.fviews[viewId];
-                const newViewSetViews = state.viewsets[viewSetId].views.filter((view) => view !== viewId);
-                state.viewsets[viewSetId].views = newViewSetViews;
+                delete state.fviews[viewID];
+                const newViewSetViews = state.viewsets[viewSetID].views.filter((view) => view !== viewID);
+                state.viewsets[viewSetID].views = newViewSetViews;
             }
         }
     }

--- a/src/state/uiSpec-reducer.ts
+++ b/src/state/uiSpec-reducer.ts
@@ -271,6 +271,24 @@ export const uiSpecificationReducer = createSlice({
                 state.fviews[sectionId] = newSection;
                 state.viewsets[viewSetId].views.push(sectionId);
             }
+        },
+        formSectionDeleted: (state: NotebookUISpec, action: PayloadAction<{ viewSetId: string, viewId: string }>) => {
+            const { viewSetId, viewId } = action.payload;
+
+            if (viewId in state.fviews) {
+                // working copy of the field names ('fields') part of the section that is to be removed
+                const sectionFields: string[] = state.fviews[viewId].fields
+                sectionFields.map((field) => {
+                    if (field in state.fields) {
+                        // remove the fields in 'fields' belonging to the section 
+                        delete state.fields[field];
+                    }
+                })
+                // remove the section from 'fviews' & 'viewsets'
+                delete state.fviews[viewId];
+                const newViewSetViews = state.viewsets[viewSetId].views.filter((view) => view !== viewId);
+                state.viewsets[viewSetId].views = newViewSetViews;
+            }
         }
     }
 })

--- a/src/state/uiSpec-reducer.ts
+++ b/src/state/uiSpec-reducer.ts
@@ -243,33 +243,18 @@ export const uiSpecificationReducer = createSlice({
                         const fviewFields: string[] = state.fviews[view].fields
                         fviewFields.map((formField) => {
                             if (formField in state.fields) {
-                                // SANITY CHECK. Don't allow the user to delete the form if they've used it in a RelatedRecordSelector field
-                                if (state.fields[formField]["component-parameters"].related_type === viewSetId) {
-                                    throw new Error(`This form is being used in a Relation Field. Please fix this and try again.`)
-                                }
-                                else {
-                                    // remove the fields in 'fields' belonging to their respective sections in the form
-                                    delete state.fields[formField]
-                                }
-                            }
-                            else {
-                                throw new Error(`Cannot delete unknown field ${formField} via viewSetDeleted action`);
+                                // remove the fields in 'fields' belonging to their respective sections in the form
+                                delete state.fields[formField]
                             }
                         })
                         // remove the sections in 'fviews' belonging to the form 
                         delete state.fviews[view];
-                    }
-                    else {
-                        throw new Error(`Cannot delete unknown section ${view} via viewSetDeleted action`);
                     }
                 })
                 // remove the form from 'viewsets' and 'visible_types'
                 delete state.viewsets[viewSetId];
                 const newVisibleTypes = state.visible_types.filter((field) => field !== viewSetId);
                 state.visible_types = newVisibleTypes;
-            }
-            else {
-                throw new Error(`Cannot delete unknown form ${viewSetId} via viewSetDeleted action`);
             }
         },
         formSectionAdded: (state: NotebookUISpec,

--- a/src/state/uiSpec-reducer.ts
+++ b/src/state/uiSpec-reducer.ts
@@ -240,8 +240,8 @@ export const uiSpecificationReducer = createSlice({
                 viewSetViews.map((view) => {
                     if (view in state.fviews) {
                         // working copy of the field names ('fields') part of the section that is part of the form that is to be removed
-                        const fviewFields: string[] = state.fviews[view].fields
-                        fviewFields.map((formField) => {
+                        const viewFields: string[] = state.fviews[view].fields
+                        viewFields.map((formField) => {
                             if (formField in state.fields) {
                                 // remove the fields in 'fields' belonging to their respective sections in the form
                                 delete state.fields[formField]


### PR DESCRIPTION
# Issue #18 
This PR takes care of delete operations.
## Summary
A user can now:
- Delete a form after confirming they are sure + validating the form they wish to delete is not being referred to in a Relation field. **Update**: user feedback now also informs the user where in the notebook the related field they need to edit is.
- Delete a section within a form after confirming they are sure.

#### Notes/Comments
- The UI/UX is a work-in-progress and I'm open to suggestions. Especially for the feedback messages in the dialogs [has been updated]. 
- There is a minor bug when deleting the last section within a form - I'll send a message on Slack with more detail to discuss [**FIXED**].