### PR TITLE
Form and sections operations

### DIFF
--- a/src/components/Fields/TemplatedStringFieldEditor.tsx
+++ b/src/components/Fields/TemplatedStringFieldEditor.tsx
@@ -67,7 +67,6 @@ export const TemplatedStringFieldEditor = ({ fieldName, viewId }: PropType) => {
         // insert {{fieldId}} at the cursor in the text area
         if (textAreaRef.current) {
             const el = textAreaRef.current as HTMLTextAreaElement;
-            console.log('tar', el);
             el.focus();
             const [start, end] = [el.selectionStart, el.selectionEnd];
             el.setRangeText(`{{${fieldId}}}`, start, end, 'select'); 

--- a/src/components/design-panel.tsx
+++ b/src/components/design-panel.tsx
@@ -59,7 +59,7 @@ export const DesignPanel = () => {
             {Object.keys(viewSets).map((key: string, index: number) => {
                 const viewSet = viewSets[key];
                 return (
-                    <Tab key={index} label={'Form:' + viewSet.label} value={index.toString()} />
+                    <Tab key={index} label={'Form: ' + viewSet.label} value={index.toString()} />
                 )})}
                 <Tab key={maxKeys} icon={<AddIcon />}
                      value={maxKeys.toString()} />

--- a/src/components/design-panel.tsx
+++ b/src/components/design-panel.tsx
@@ -36,74 +36,84 @@ export const DesignPanel = () => {
 
     const addNewForm = () => {
         try {
-            dispatch({type: 'ui-specification/viewSetAdded', payload: {formName: newFormName}})
+            dispatch({ type: 'ui-specification/viewSetAdded', payload: { formName: newFormName } })
         } catch (error: unknown) {
             error instanceof Error &&
                 setAlertMessage(error.message);
         }
     }
 
+    const moveForm = (viewSetID: string, moveDirection: 'left' | 'right') => {
+        if (moveDirection === 'left') {
+            dispatch({ type: 'ui-specification/viewSetMoved', payload: { viewSetId: viewSetID, direction: 'left' } });
+            //setTabIndex((parseInt(tabIndex)-1).toString());
+        }
+        else {
+            dispatch({ type: 'ui-specification/viewSetMoved', payload: { viewSetId: viewSetID, direction: 'right' } });
+            //setTabIndex((parseInt(tabIndex)+1).toString());
+        }
+    }
+
     const maxKeys = Object.keys(viewSets).length;
     console.log('DesignPanel');
-
+    
     return (
         <TabContext value={tabIndex}>
-            
-        <Alert severity="info">Define the user interface for your notebook here.  Add one
-        or more forms to collect data from users.  Each form can have one or more sections.  
-        Each section has one or more form fields.
-        </Alert>
 
-        <Box sx={{ borderBottom: 1, borderColor: 'divider' }}>
-            <Tabs value={tabIndex} onChange={handleTabChange} aria-label="basic tabs example">
-            {Object.keys(viewSets).map((key: string, index: number) => {
-                const viewSet = viewSets[key];
-                return (
-                    <Tab key={index} label={'Form: ' + viewSet.label} value={index.toString()} />
-                )})}
-                <Tab key={maxKeys} icon={<AddIcon />}
-                     value={maxKeys.toString()} />
-            </Tabs>
-        </Box>
-        {
-            // Each viewSet defines a Form which should be a Tab here
-            
-            Object.keys(viewSets).map((key: string, index: number) => {
-                return (
-                    <TabPanel key={index} value={index.toString()} sx={{ paddingX: 0 }}>
-                        <FormEditor viewSetId={key} />
-                    </TabPanel>
-                )
-        })}
-        <TabPanel key={maxKeys} value={maxKeys.toString()}>
-            <Grid container spacing={2} pt={3}>
-                <Grid item xs={12} sm={6}>
-                    <TextField
-                        fullWidth
-                        required
-                        label="Form Name"
-                        helperText="Enter a name for the form"
-                        name="formName"
-                        data-testid="formName"
-                        value={newFormName}
-                        onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
-                            setNewFormName(event.target.value);
-                        }}
-                    />
-                </Grid>
-                <Grid item xs={12} sm={6}>
-                    <Button variant="contained" color="primary" onClick={addNewForm}>
-                        Add New Form
-                    </Button>
-                </Grid>
-                <Grid item xs={12}>
-                    {alertMessage && <Alert severity="error">{alertMessage}</Alert>}
-                </Grid>
-            </Grid>
+            <Alert severity="info">
+                Define the user interface for your notebook here.  Add one
+                or more forms to collect data from users.  Each form can have one or more sections.
+                Each section has one or more form fields.
+            </Alert>
 
+            <Box sx={{ borderBottom: 1, borderColor: 'divider' }}>
+                <Tabs value={tabIndex} onChange={handleTabChange} aria-label="basic tabs example">
+                    {Object.keys(viewSets).map((key: string, index: number) => {
+                        const viewSet = viewSets[key];
+                        return (
+                            <Tab key={index} label={'Form: ' + viewSet.label} value={index.toString()} />
+                        )
+                    })}
+                    <Tab key={maxKeys} icon={<AddIcon />}
+                        value={maxKeys.toString()} />
+                </Tabs>
+            </Box>
+            {
+                // Each viewSet defines a Form which should be a Tab here
 
-        </TabPanel>
+                Object.keys(viewSets).map((key: string, index: number) => {
+                    return (
+                        <TabPanel key={index} value={index.toString()} sx={{ paddingX: 0 }}>
+                            <FormEditor viewSetId={key} moveCallback={moveForm} />
+                        </TabPanel>
+                    )
+                })}
+            <TabPanel key={maxKeys} value={maxKeys.toString()}>
+                <Grid container spacing={2} pt={3}>
+                    <Grid item xs={12} sm={6}>
+                        <TextField
+                            fullWidth
+                            required
+                            label="Form Name"
+                            helperText="Enter a name for the form"
+                            name="formName"
+                            data-testid="formName"
+                            value={newFormName}
+                            onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
+                                setNewFormName(event.target.value);
+                            }}
+                        />
+                    </Grid>
+                    <Grid item xs={12} sm={6}>
+                        <Button variant="contained" color="primary" onClick={addNewForm}>
+                            Add New Form
+                        </Button>
+                    </Grid>
+                    <Grid item xs={12}>
+                        {alertMessage && <Alert severity="error">{alertMessage}</Alert>}
+                    </Grid>
+                </Grid>
+            </TabPanel>
         </TabContext>
     )
-
 };

--- a/src/components/design-panel.tsx
+++ b/src/components/design-panel.tsx
@@ -70,7 +70,7 @@ export const DesignPanel = () => {
             
             Object.keys(viewSets).map((key: string, index: number) => {
                 return (
-                    <TabPanel key={index} value={index.toString()}>
+                    <TabPanel key={index} value={index.toString()} sx={{ paddingX: 0 }}>
                         <FormEditor viewSetId={key} />
                     </TabPanel>
                 )

--- a/src/components/design-panel.tsx
+++ b/src/components/design-panel.tsx
@@ -47,22 +47,24 @@ export const DesignPanel = () => {
     const handleCheckboxTabChange = (viewSetID: string, ticked: boolean) => {
         if (!ticked) {
             // add form to the array of unticked forms (the form has already been removed from visible_types at this point)
-            setUntickedForms([...untickedForms, viewSetID])
+            setUntickedForms([...untickedForms, viewSetID]);
             // ensure the tab index jumps to the end of all the tabs
             setTabIndex(`${maxKeys - 1}`);
         }
         else {
             // filter the form out of the array of unticked forms (the form has already been re-added to visible_types at this point)
-            setUntickedForms(untickedForms.filter((untickedForm) => untickedForm !== viewSetID))
+            setUntickedForms(untickedForms.filter((untickedForm) => untickedForm !== viewSetID));
             // ensure the tab index jumps somewhat intuitively
             setTabIndex(`${visibleTypes.length}`);
         }
     }
 
     const addNewForm = () => {
+        setAlertMessage('');
         try {
-            dispatch({ type: 'ui-specification/viewSetAdded', payload: { formName: newFormName } })
-            setTabIndex(`${visibleTypes.length}`)
+            dispatch({ type: 'ui-specification/viewSetAdded', payload: { formName: newFormName } });
+            setTabIndex(`${visibleTypes.length}`);
+            setAlertMessage('');
         }
         catch (error: unknown) {
             error instanceof Error &&
@@ -96,6 +98,8 @@ export const DesignPanel = () => {
                     value={tabIndex}
                     onChange={handleTabChange}
                     aria-label='form tabs'
+                    variant='scrollable'
+                    scrollButtons={false}
                     indicatorColor={(tabIndex >= `${visibleTypes.length}` && tabIndex < `${maxKeys}`) ? 'secondary' : 'primary'}
                 >
                     {visibleTypes.map((form: string, index: number) => {
@@ -179,18 +183,23 @@ export const DesignPanel = () => {
             <TabPanel key={maxKeys} value={maxKeys.toString()}>
                 <Grid container spacing={2} pt={3}>
                     <Grid item xs={12} sm={6}>
-                        <TextField
-                            fullWidth
-                            required
-                            label="Form Name"
-                            helperText="Enter a name for the form"
-                            name="formName"
-                            data-testid="formName"
-                            value={newFormName}
-                            onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
-                                setNewFormName(event.target.value);
-                            }}
-                        />
+                        <form onSubmit={(e: React.FormEvent<HTMLFormElement>) => {
+                            e.preventDefault();
+                            addNewForm();
+                        }}>
+                            <TextField
+                                fullWidth
+                                required
+                                label="Form Name"
+                                helperText="Enter a name for the form."
+                                name="formName"
+                                data-testid="formName"
+                                value={newFormName}
+                                onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
+                                    setNewFormName(event.target.value);
+                                }}
+                            />
+                        </form>
                     </Grid>
                     <Grid item xs={12} sm={6}>
                         <Button variant="contained" color="primary" onClick={addNewForm}>

--- a/src/components/design-panel.tsx
+++ b/src/components/design-panel.tsx
@@ -13,7 +13,9 @@
 // limitations under the License.
 
 import { Alert, Box, Button, Grid, Tab, Tabs, TextField } from "@mui/material";
+
 import AddIcon from '@mui/icons-material/Add';
+
 import { TabContext, TabPanel } from "@mui/lab";
 import { useState } from "react";
 import { useAppDispatch, useAppSelector } from "../state/hooks";
@@ -24,20 +26,45 @@ import { Notebook } from "../state/initial";
 export const DesignPanel = () => {
 
     const viewSets = useAppSelector((state: Notebook) => state['ui-specification'].viewsets, shallowEqual);
+    const visibleTypes: string[] = useAppSelector((state: Notebook) => state['ui-specification'].visible_types)
     const dispatch = useAppDispatch();
 
     const [tabIndex, setTabIndex] = useState('0');
     const [newFormName, setNewFormName] = useState('New Form');
     const [alertMessage, setAlertMessage] = useState<string>('');
+    const [untickedForms, setUntickedForms] = useState<string[]>(Object.keys(viewSets).filter((form) => !visibleTypes.includes(form)));
+
+    console.log('DesignPanel');
+    console.log('tabIndex is', tabIndex);
+    console.log('visible forms ', visibleTypes, '& unticked forms ', untickedForms);
+
+    const maxKeys = Object.keys(viewSets).length;
 
     const handleTabChange = (_event: React.SyntheticEvent, newValue: number) => {
         setTabIndex(newValue.toString());
-    };
+    }
+
+    const handleCheckboxTabChange = (viewSetID: string, ticked: boolean) => {
+        if (!ticked) {
+            // add form to the array of unticked forms (the form has already been removed from visible_types at this point)
+            setUntickedForms([...untickedForms, viewSetID])
+            // ensure the tab index jumps to the end of all the tabs
+            setTabIndex(`${maxKeys - 1}`);
+        }
+        else {
+            // filter the form out of the array of unticked forms (the form has already been re-added to visible_types at this point)
+            setUntickedForms(untickedForms.filter((untickedForm) => untickedForm !== viewSetID))
+            // ensure the tab index jumps somewhat intuitively
+            setTabIndex(`${visibleTypes.length}`);
+        }
+    }
 
     const addNewForm = () => {
         try {
             dispatch({ type: 'ui-specification/viewSetAdded', payload: { formName: newFormName } })
-        } catch (error: unknown) {
+            setTabIndex(`${visibleTypes.length}`)
+        }
+        catch (error: unknown) {
             error instanceof Error &&
                 setAlertMessage(error.message);
         }
@@ -46,48 +73,109 @@ export const DesignPanel = () => {
     const moveForm = (viewSetID: string, moveDirection: 'left' | 'right') => {
         if (moveDirection === 'left') {
             dispatch({ type: 'ui-specification/viewSetMoved', payload: { viewSetId: viewSetID, direction: 'left' } });
-            //setTabIndex((parseInt(tabIndex)-1).toString());
+            setTabIndex(`${parseInt(tabIndex) - 1}`);
         }
         else {
             dispatch({ type: 'ui-specification/viewSetMoved', payload: { viewSetId: viewSetID, direction: 'right' } });
-            //setTabIndex((parseInt(tabIndex)+1).toString());
+            setTabIndex(`${parseInt(tabIndex) + 1}`);
         }
     }
 
-    const maxKeys = Object.keys(viewSets).length;
-    console.log('DesignPanel');
-    
+
     return (
         <TabContext value={tabIndex}>
 
-            <Alert severity="info">
+            <Alert severity="info" sx={{ marginBottom: 2 }}>
                 Define the user interface for your notebook here.  Add one
                 or more forms to collect data from users.  Each form can have one or more sections.
                 Each section has one or more form fields.
             </Alert>
 
-            <Box sx={{ borderBottom: 1, borderColor: 'divider' }}>
-                <Tabs value={tabIndex} onChange={handleTabChange} aria-label="basic tabs example">
-                    {Object.keys(viewSets).map((key: string, index: number) => {
-                        const viewSet = viewSets[key];
+            <Box sx={{ borderBottom: 2, borderColor: 'divider' }}>
+                <Tabs
+                    value={tabIndex}
+                    onChange={handleTabChange}
+                    aria-label='form tabs'
+                    indicatorColor={(tabIndex >= `${visibleTypes.length}` && tabIndex < `${maxKeys}`) ? 'secondary' : 'primary'}
+                >
+                    {visibleTypes.map((form: string, index: number) => {
                         return (
-                            <Tab key={index} label={'Form: ' + viewSet.label} value={index.toString()} />
+                            <Tab key={index} value={`${index}`} label={`Form: ${viewSets[form].label}`}
+                                sx={{
+                                    '&.MuiTab-root': {
+                                        backgroundColor: '#F5FCE8',
+                                        borderTopLeftRadius: '10px',
+                                        borderTopRightRadius: '10px',
+                                        marginRight: '0.5em'
+                                    },
+                                    '&.Mui-selected': {
+                                        border: '0.5px solid #669911',
+                                    },
+                                    '&:hover': {
+                                        color: '#669911',
+                                        opacity: 1,
+                                    },
+                                }}
+                            />
                         )
                     })}
-                    <Tab key={maxKeys} icon={<AddIcon />}
-                        value={maxKeys.toString()} />
+                    {untickedForms.map((form: string, index: number) => {
+                        const startIndex: number = index + visibleTypes.length;
+                        return (
+                            <Tab key={startIndex} value={`${startIndex}`} label={`Form: ${viewSets[form].label}`}
+                                sx={{
+                                    '&.MuiTab-root': {
+                                        backgroundColor: '#FFF4E5',
+                                        borderTopLeftRadius: '10px',
+                                        borderTopRightRadius: '10px',
+                                        marginX: '0.25em'
+                                    },
+                                    '&.Mui-selected': {
+                                        color: '#E18200',
+                                        border: '0.5px solid #E18200',
+                                    },
+                                    '&:hover': {
+                                        color: '#E18200',
+                                        opacity: 1,
+                                    },
+                                }}
+                            />
+                        )
+                    })}
+                    <Tab key={maxKeys} value={maxKeys.toString()} icon={<AddIcon />}
+                        sx={{
+                            '&.MuiTab-root': {
+                                borderTopLeftRadius: '10px',
+                                borderTopRightRadius: '10px',
+                                marginLeft: '0.5em'
+                            },
+                            '&.Mui-selected': {
+                                color: '#669911',
+                            },
+                            '&:hover': {
+                                color: '#669911',
+                                opacity: 1,
+                            },
+                        }}
+                    />
                 </Tabs>
             </Box>
-            {
-                // Each viewSet defines a Form which should be a Tab here
 
-                Object.keys(viewSets).map((key: string, index: number) => {
-                    return (
-                        <TabPanel key={index} value={index.toString()} sx={{ paddingX: 0 }}>
-                            <FormEditor viewSetId={key} moveCallback={moveForm} />
-                        </TabPanel>
-                    )
-                })}
+            {visibleTypes.map((form: string, index: number) => {
+                return (
+                    <TabPanel key={index} value={`${index}`} sx={{ paddingX: 0 }}>
+                        <FormEditor viewSetId={form} moveCallback={moveForm} moveButtonsDisabled={false} handleChangeCallback={handleCheckboxTabChange} />
+                    </TabPanel>
+                )
+            })}
+            {untickedForms.map((form: string, index: number) => {
+                const startIndex: number = index + visibleTypes.length;
+                return (
+                    <TabPanel key={startIndex} value={`${startIndex}`} sx={{ paddingX: 0 }}>
+                        <FormEditor viewSetId={form} moveCallback={moveForm} moveButtonsDisabled={true} handleChangeCallback={handleCheckboxTabChange} />
+                    </TabPanel>
+                )
+            })}
             <TabPanel key={maxKeys} value={maxKeys.toString()}>
                 <Grid container spacing={2} pt={3}>
                     <Grid item xs={12} sm={6}>
@@ -114,6 +202,7 @@ export const DesignPanel = () => {
                     </Grid>
                 </Grid>
             </TabPanel>
+
         </TabContext>
     )
 };

--- a/src/components/field-list.tsx
+++ b/src/components/field-list.tsx
@@ -47,7 +47,6 @@ export const FieldList = ({viewSetId, viewId}: Props) => {
     }
 
     const addField = () => {
-        console.log('addField', dialogState);
         dispatch({
             type: 'ui-specification/fieldAdded',
             payload: {

--- a/src/components/form-editor.tsx
+++ b/src/components/form-editor.tsx
@@ -202,20 +202,6 @@ export const FormEditor = ({ viewSetId }: { viewSetId: string }) => {
                 </Grid>
 
                 <Grid item xs={3}>
-                    <FormControlLabel
-                        control={<Checkbox
-                            checked={visibleTypes.includes(viewSetId)}
-                            size="small"
-                            onChange={(e) => handleChange(e.target.checked)}
-                        />}
-                        label="Include 'Add New Record' button"
-                    />
-                    <FormHelperText error={error}>
-                        {error && "This can only be unticked when there is more than 1 (visible) form."}
-                    </FormHelperText>
-                </Grid>
-
-                <Grid item xs={3}>
                     <Button variant="text" size="medium" startIcon={<EditIcon />} onClick={() => setEditMode(true)}>
                         Edit form name
                     </Button>
@@ -252,7 +238,21 @@ export const FormEditor = ({ viewSetId }: { viewSetId: string }) => {
                 </Grid>
 
                 <Grid item xs={3}>
+                    <FormControlLabel
+                        control={<Checkbox
+                            checked={visibleTypes.includes(viewSetId)}
+                            size="small"
+                            onChange={(e) => handleChange(e.target.checked)}
+                        />}
+                        label="Include 'Add New Record' button"
+                    />
+                    <FormHelperText error={error}>
+                        {error && "This can only be unticked when there is more than 1 (visible) form."}
+                    </FormHelperText>
+                </Grid>
 
+                <Grid item xs={3}>
+                /* move left and right buttons will be here */
                 </Grid>
             </Grid>
 

--- a/src/components/form-editor.tsx
+++ b/src/components/form-editor.tsx
@@ -81,7 +81,7 @@ export const FormEditor = ({ viewSetId, moveCallback }: Props) => {
             dispatch({ type: 'ui-specification/formVisibilityUpdated', payload: { viewSetId, ticked: checked, initialIndex: initialIndex } });
         }
         else {
-            setAlertMessage('This must remain ticked in at least one (1) form.');
+            setAlertMessage(`This must remain ticked in at least one (1) form.`);
         }
     }
 
@@ -134,8 +134,8 @@ export const FormEditor = ({ viewSetId, moveCallback }: Props) => {
     const deleteConfirmation = () => {
         setOpen(true);
         setPreventDeleteDialog(false);
-        setDeleteAlertTitle("Are you sure you want to delete this form?");
-        setDeleteAlertMessage("All fields in the form will also be deleted.");
+        setDeleteAlertTitle(`Are you sure you want to delete this form?`);
+        setDeleteAlertMessage(`All fields in the form will also be deleted.`);
     }
 
     const findRelatedFieldLocation = (fieldName: string | undefined) => {
@@ -158,8 +158,8 @@ export const FormEditor = ({ viewSetId, moveCallback }: Props) => {
                                 const sectionLabel: string = fviewsEntries[idx][1].label;
 
                                 // setting the dialog text here
-                                setDeleteAlertTitle("Form cannot be deleted.");
-                                setDeleteAlertMessage("Please update the field '" + fieldName + "', found in form " + formLabel + " section " + sectionLabel + ", to remove the reference to allow this form to be deleted.");
+                                setDeleteAlertTitle(`Form cannot be deleted.`);
+                                setDeleteAlertMessage(`Please update the field '${fieldName}', found in form ${formLabel} section ${sectionLabel}, to remove the reference to allow this form to be deleted.`);
                             }
                         })
                     })
@@ -273,20 +273,24 @@ export const FormEditor = ({ viewSetId, moveCallback }: Props) => {
 
                 <Grid item xs={2}>
                     <Tooltip title='Move left'>
-                        <IconButton
-                            disabled={Object.keys(viewsets).indexOf(viewSetId) === 0 ? true : false}
-                            onClick={() => moveForm(viewSetId, 'left')}
-                            aria-label='left' size='medium'>
-                            <ArrowBackRoundedIcon />
-                        </IconButton>
+                        <span>
+                            <IconButton
+                                disabled={Object.keys(viewsets).indexOf(viewSetId) === 0 ? true : false}
+                                onClick={() => moveForm(viewSetId, 'left')}
+                                aria-label='left' size='medium'>
+                                <ArrowBackRoundedIcon />
+                            </IconButton>
+                        </span>
                     </Tooltip>
                     <Tooltip title='Move right'>
-                        <IconButton
-                            disabled={Object.keys(viewsets).indexOf(viewSetId) === (Object.keys(viewsets).length - 1) ? true : false}
-                            onClick={() => moveForm(viewSetId, 'right')}
-                            aria-label='right' size='medium'>
-                            <ArrowForwardRoundedIcon />
-                        </IconButton>
+                        <span>
+                            <IconButton
+                                disabled={Object.keys(viewsets).indexOf(viewSetId) === (Object.keys(viewsets).length - 1) ? true : false}
+                                onClick={() => moveForm(viewSetId, 'right')}
+                                aria-label='right' size='medium'>
+                                <ArrowForwardRoundedIcon />
+                            </IconButton>
+                        </span>
                     </Tooltip>
                 </Grid>
 

--- a/src/components/form-editor.tsx
+++ b/src/components/form-editor.tsx
@@ -251,34 +251,39 @@ export const FormEditor = ({ viewSetId, moveCallback, moveButtonsDisabled, handl
                         Edit form name
                     </Button>
                     {editMode &&
-                        <TextField
-                            size="small"
-                            margin="dense"
-                            label="Form Name"
-                            name="label"
-                            data-testid="label"
-                            InputProps={{
-                                endAdornment: (
-                                    <InputAdornment position="end">
-                                        <Tooltip title="Done">
-                                            <IconButton size="small" onClick={() => setEditMode(false)}>
-                                                <DoneRoundedIcon />
-                                            </IconButton>
-                                        </Tooltip>
-                                        <Tooltip title="Close">
-                                            <IconButton size="small" onClick={() => setEditMode(false)}>
-                                                <CloseRoundedIcon />
-                                            </IconButton>
-                                        </Tooltip>
-                                    </InputAdornment>
-                                ),
-                            }}
-                            value={viewSet.label}
-                            onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
-                                updateFormLabel(event.target.value);
-                            }}
-                            sx={{ '& .MuiInputBase-root': { paddingRight: 0 } }}
-                        />
+                        <form onSubmit={(e: React.FormEvent<HTMLFormElement>) => {
+                            e.preventDefault();
+                            setEditMode(false);
+                        }}>
+                            <TextField
+                                size="small"
+                                margin="dense"
+                                label="Form Name"
+                                name="label"
+                                data-testid="label"
+                                InputProps={{
+                                    endAdornment: (
+                                        <InputAdornment position="end">
+                                            <Tooltip title="Done">
+                                                <IconButton size="small" type="submit">
+                                                    <DoneRoundedIcon />
+                                                </IconButton>
+                                            </Tooltip>
+                                            <Tooltip title="Close">
+                                                <IconButton size="small" onClick={() => setEditMode(false)}>
+                                                    <CloseRoundedIcon />
+                                                </IconButton>
+                                            </Tooltip>
+                                        </InputAdornment>
+                                    ),
+                                }}
+                                value={viewSet.label}
+                                onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
+                                    updateFormLabel(event.target.value);
+                                }}
+                                sx={{ '& .MuiInputBase-root': { paddingRight: 0 } }}
+                            />
+                        </form>
                     }
                 </Grid>
 
@@ -360,28 +365,33 @@ export const FormEditor = ({ viewSetId, moveCallback, moveButtonsDisabled, handl
                                 <Grid container justifyContent="center"
                                     alignItems="center" item xs={12} direction="column">
                                     <Alert severity="success">Form has been created. Add a section to get started.</Alert>
-                                    <TextField
-                                        required
-                                        label="Section Name"
-                                        name="sectionName"
-                                        data-testid="sectionName"
-                                        value={newSectionName}
-                                        onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
-                                            setNewSectionName(event.target.value);
-                                        }}
-                                        sx={{ '& .MuiInputBase-root': { paddingRight: 1 }, mt: 3 }}
-                                        InputProps={{
-                                            endAdornment: (
-                                                <InputAdornment position="end">
-                                                    <Tooltip title="Add">
-                                                        <IconButton onClick={() => addNewSection(viewSetId, newSectionName)}>
-                                                            <AddRoundedIcon />
-                                                        </IconButton>
-                                                    </Tooltip>
-                                                </InputAdornment>
-                                            ),
-                                        }}
-                                    />
+                                    <form onSubmit={(e: React.FormEvent<HTMLFormElement>) => {
+                                        e.preventDefault();
+                                        addNewSection(viewSetId, newSectionName);
+                                    }}>
+                                        <TextField
+                                            required
+                                            label="Section Name"
+                                            name="sectionName"
+                                            data-testid="sectionName"
+                                            value={newSectionName}
+                                            onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
+                                                setNewSectionName(event.target.value);
+                                            }}
+                                            sx={{ '& .MuiInputBase-root': { paddingRight: 1 }, mt: 3 }}
+                                            InputProps={{
+                                                endAdornment: (
+                                                    <InputAdornment position="end">
+                                                        <Tooltip title="Add">
+                                                            <IconButton type="submit">
+                                                                <AddRoundedIcon />
+                                                            </IconButton>
+                                                        </Tooltip>
+                                                    </InputAdornment>
+                                                ),
+                                            }}
+                                        />
+                                    </form>
                                 </Grid>
                                 {addAlertMessage && <Alert severity="error">{addAlertMessage}</Alert>}
                             </Grid>
@@ -391,7 +401,6 @@ export const FormEditor = ({ viewSetId, moveCallback, moveButtonsDisabled, handl
                                     <SectionEditor viewSetId={viewSetId} viewId={viewSet.views[activeStep]} viewSet={viewSet} deleteCallback={deleteSection} addCallback={addNewSection} moveCallback={moveSection} />
                                 </Grid>
                             )
-
                         }
                     </Grid>
                 </Card>

--- a/src/components/form-editor.tsx
+++ b/src/components/form-editor.tsx
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { Grid, Paper, Alert, Stepper, Typography, Step, Button, StepButton, TextField, Dialog, DialogTitle, DialogActions, DialogContent, DialogContentText, Card, InputAdornment, Tooltip, IconButton, Checkbox, FormControlLabel, FormHelperText } from "@mui/material";
-import DeleteIcon from "@mui/icons-material/Delete";
-import EditIcon from '@mui/icons-material/Edit';
+import { Grid, Paper, Alert, Stepper, Typography, Step, Button, StepButton, TextField, Dialog, DialogTitle, DialogActions, DialogContent, DialogContentText, Card, InputAdornment, Tooltip, IconButton, Checkbox, FormControlLabel } from "@mui/material";
+import DeleteRoundedIcon from '@mui/icons-material/DeleteRounded';
+import EditRoundedIcon from '@mui/icons-material/EditRounded';
 import CloseRoundedIcon from '@mui/icons-material/CloseRounded';
 import DoneRoundedIcon from '@mui/icons-material/DoneRounded';
 
@@ -40,7 +40,6 @@ export const FormEditor = ({ viewSetId }: { viewSetId: string }) => {
     console.log('FormEditor visible_types', visibleTypes);
 
     const [activeStep, setActiveStep] = useState(0);
-    const [newSectionName, setNewSectionName] = useState('New Section');
     const [alertMessage, setAlertMessage] = useState('');
     const [open, setOpen] = useState(false);
     const [deleteAlertMessage, setDeleteAlertMessage] = useState('');
@@ -48,7 +47,6 @@ export const FormEditor = ({ viewSetId }: { viewSetId: string }) => {
     const [preventDeleteDialog, setPreventDeleteDialog] = useState(false);
     const [editMode, setEditMode] = useState(false);
     const [checked, setChecked] = useState(true);
-    const [error, setError] = useState(false);
     const [initialIndex, setInitialIndex] = useState(visibleTypes.indexOf(viewSetId));
 
     const handleStep = (step: number) => () => {
@@ -59,32 +57,21 @@ export const FormEditor = ({ viewSetId }: { viewSetId: string }) => {
         setOpen(false);
     };
 
-    console.log('length ', Object.keys(viewsets).length)
     const handleChange = (ticked: boolean) => {
         // there must be >1 forms in the notebook, and, therefore, >1 visible forms, in order to be able to untick the checkbox
         if ((Object.keys(viewsets).length > 1 && visibleTypes.length > 1) || ticked) {
-            setError(false);
+            setAlertMessage('');
             dispatch({ type: 'ui-specification/formVisibilityUpdated', payload: { viewSetId, ticked, initialIndex } });
         }
         // in the case that there are multiple forms in the notebook, but none are visible, allow to re-tick the checkbox
         else if (visibleTypes.length === 0) {
-            setError(false);
+            setAlertMessage('');
             setChecked(ticked)
             setInitialIndex(0)
             dispatch({ type: 'ui-specification/formVisibilityUpdated', payload: { viewSetId, ticked: checked, initialIndex: initialIndex } });
         }
         else {
-            setError(true);
-        }
-
-    }
-
-    const addNewSection = () => {
-        try {
-            dispatch({ type: 'ui-specification/formSectionAdded', payload: { viewSetId: viewSetId, sectionLabel: newSectionName } });
-        } catch (error: unknown) {
-            error instanceof Error &&
-                setAlertMessage(error.message);
+            setAlertMessage('This must remain ticked in at least one (1) form.');
         }
     }
 
@@ -169,9 +156,9 @@ export const FormEditor = ({ viewSetId }: { viewSetId: string }) => {
 
     return (
         <Grid container spacing={2}>
-            <Grid container item xs={12}>
+            <Grid container item xs={12} spacing={1}>
                 <Grid item xs={3}>
-                    <Button variant="text" color="error" size="medium" startIcon={<DeleteIcon />} onClick={deleteConfirmation}>
+                    <Button variant="text" color="error" size="medium" startIcon={<DeleteRoundedIcon />} onClick={deleteConfirmation}>
                         Delete this form
                     </Button>
                     <Dialog
@@ -202,7 +189,7 @@ export const FormEditor = ({ viewSetId }: { viewSetId: string }) => {
                 </Grid>
 
                 <Grid item xs={3}>
-                    <Button variant="text" size="medium" startIcon={<EditIcon />} onClick={() => setEditMode(true)}>
+                    <Button variant="text" size="medium" startIcon={<EditRoundedIcon />} onClick={() => setEditMode(true)}>
                         Edit form name
                     </Button>
                     {editMode &&
@@ -238,6 +225,10 @@ export const FormEditor = ({ viewSetId }: { viewSetId: string }) => {
                 </Grid>
 
                 <Grid item xs={3}>
+                /* move left and right buttons will be here */
+                </Grid>
+
+                <Grid item xs={3}>
                     <FormControlLabel
                         control={<Checkbox
                             checked={visibleTypes.includes(viewSetId)}
@@ -246,13 +237,7 @@ export const FormEditor = ({ viewSetId }: { viewSetId: string }) => {
                         />}
                         label="Include 'Add New Record' button"
                     />
-                    <FormHelperText error={error}>
-                        {error && "This can only be unticked when there is more than 1 (visible) form."}
-                    </FormHelperText>
-                </Grid>
-
-                <Grid item xs={3}>
-                /* move left and right buttons will be here */
+                    {alertMessage && <Alert severity="error">{alertMessage}</Alert>}
                 </Grid>
             </Grid>
 
@@ -280,30 +265,6 @@ export const FormEditor = ({ viewSetId }: { viewSetId: string }) => {
                                     <SectionEditor viewSetId={viewSetId} viewId={viewSet.views[activeStep]} deleteCallback={deleteSection} />
                                 )
                             }
-                        </Grid>
-                    </Grid>
-                    <Grid container spacing={2} p={3}>
-                        <Grid item xs={12} sm={6}>
-                            <TextField
-                                fullWidth
-                                required
-                                label="Section Name"
-                                helperText="Enter a name for the form section."
-                                name="sectionName"
-                                data-testid="sectionName"
-                                value={newSectionName}
-                                onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
-                                    setNewSectionName(event.target.value);
-                                }}
-                            />
-                        </Grid>
-                        <Grid item xs={12} sm={6}>
-                            <Button variant="contained" color="primary" onClick={addNewSection}>
-                                Add New Section
-                            </Button>
-                        </Grid>
-                        <Grid item xs={12}>
-                            {alertMessage && <Alert severity="error">{alertMessage}</Alert>}
                         </Grid>
                     </Grid>
                 </Card>

--- a/src/components/form-editor.tsx
+++ b/src/components/form-editor.tsx
@@ -86,17 +86,17 @@ export const FormEditor = ({ viewSetId }: { viewSetId: string }) => {
     const findRelatedFieldLocation = (fieldName: string | undefined) => {
         // making fviews iterable
         const fviewsEntries = Object.entries(views)
-        fviewsEntries.map((_viewId, idx) => {
+        fviewsEntries.forEach((_viewId, idx) => {
             // iterating over every section's fields array to find fieldName
-            fviewsEntries[idx][1].fields.map((field) => {
+            fviewsEntries[idx][1].fields.forEach((field) => {
                 if (field === fieldName) {
                     // extracting which section fieldName belongs to
                     const sectionToFind = fviewsEntries[idx][0];
                     // making viewsets iterable
                     const viewsetsEntries = Object.entries(viewsets);
-                    viewsetsEntries.map((_viewSetId, idx) => {
+                    viewsetsEntries.forEach((_viewSetId, idx) => {
                         // iterating over every form's views array to find the section
-                        viewsetsEntries[idx][1].views.map((view) => {
+                        viewsetsEntries[idx][1].views.forEach((view) => {
                             if (view === sectionToFind) {
                                 // we made it! now extract the form and section labels
                                 const formLabel: string = viewsetsEntries[idx][1].label;
@@ -118,7 +118,7 @@ export const FormEditor = ({ viewSetId }: { viewSetId: string }) => {
         const fieldValues = Object.values(fields)
         let flag: boolean = false;
         // search through all the values for mention of the form to be deleted in the related_type param
-        fieldValues.map((fieldValue) => {
+        fieldValues.forEach((fieldValue) => {
             if (fieldValue["component-parameters"].related_type === viewSetId) {
                 flag = true;
                 // extracting the name of the field to advise the user
@@ -144,62 +144,75 @@ export const FormEditor = ({ viewSetId }: { viewSetId: string }) => {
 
     return (
         <Grid container spacing={2}>
-            <Grid item xs={12}>
-                <Button variant="text" size="medium" startIcon={<EditIcon />} onClick={() => setEditMode(true)}>
-                    Edit the form name
-                </Button>
-                {editMode &&
-                    <TextField
-                        label="Form Name"
-                        name="label"
-                        data-testid="label"
-                        disabled={!editMode}
-                        InputProps={{
-                            endAdornment: (
-                                <InputAdornment position="end">
-                                    <Tooltip title="Close">
-                                        <IconButton onClick={() => setEditMode(false)}>
-                                            <CloseRoundedIcon />
-                                        </IconButton>
-                                    </Tooltip>
-                                </InputAdornment>
-                            ),
-                        }}
-                        value={viewSet.label}
-                        onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
-                            updateFormLabel(event.target.value);
-                        }}
-                    />
-                }
+            <Grid container item xs={12}>
+                <Grid item xs={3}>
+                    <Button variant="text" color="error" size="medium" startIcon={<DeleteIcon />} onClick={deleteConfirmation}>
+                        Delete this form
+                    </Button>
+                    <Dialog
+                        open={open}
+                        onClose={handleClose}
+                        aria-labelledby="alert-dialog-title"
+                        aria-describedby="alert-dialog-description"
+                    >
+                        <DialogTitle id="alert-dialog-title">
+                            {deleteAlertTitle}
+                        </DialogTitle>
+                        <DialogContent>
+                            <DialogContentText id="alert-dialog-description">
+                                {deleteAlertMessage}
+                            </DialogContentText>
+                        </DialogContent>
+                        {preventDeleteDialog ?
+                            <DialogActions>
+                                <Button onClick={handleClose}>OK</Button>
+                            </DialogActions>
+                            :
+                            <DialogActions>
+                                <Button onClick={deleteForm}>Yes</Button>
+                                <Button onClick={handleClose}>No</Button>
+                            </DialogActions>
+                        }
+                    </Dialog>
+                </Grid>
 
-                <Button variant="text" color="error" size="medium" startIcon={<DeleteIcon />} onClick={deleteConfirmation}>
-                    Delete this form
-                </Button>
-                <Dialog
-                    open={open}
-                    onClose={handleClose}
-                    aria-labelledby="alert-dialog-title"
-                    aria-describedby="alert-dialog-description"
-                >
-                    <DialogTitle id="alert-dialog-title">
-                        {deleteAlertTitle}
-                    </DialogTitle>
-                    <DialogContent>
-                        <DialogContentText id="alert-dialog-description">
-                            {deleteAlertMessage}
-                        </DialogContentText>
-                    </DialogContent>
-                    {preventDeleteDialog ?
-                        <DialogActions>
-                            <Button onClick={handleClose}>OK</Button>
-                        </DialogActions>
-                        :
-                        <DialogActions>
-                            <Button onClick={deleteForm}>Yes</Button>
-                            <Button onClick={handleClose}>No</Button>
-                        </DialogActions>
+                <Grid item xs={3}>
+                    <Button variant="text" size="medium" startIcon={<EditIcon />} onClick={() => setEditMode(true)}>
+                        Edit form name
+                    </Button>
+                    {editMode &&
+                        <TextField
+                            size="small"
+                            margin="dense"
+                            label="Form Name"
+                            name="label"
+                            data-testid="label"
+                            InputProps={{
+                                endAdornment: (
+                                    <InputAdornment position="end">
+                                        <Tooltip title="Done / Close">
+                                            <IconButton onClick={() => setEditMode(false)}>
+                                                <CloseRoundedIcon />
+                                            </IconButton>
+                                        </Tooltip>
+                                    </InputAdornment>
+                                ),
+                            }}
+                            value={viewSet.label}
+                            onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
+                                updateFormLabel(event.target.value);
+                            }}
+                        />
                     }
-                </Dialog>
+                </Grid>
+
+                <Grid item xs={3}>
+
+                </Grid>
+
+                <Grid item xs={3}>
+
+                </Grid>
             </Grid>
 
             <Grid item xs={12}>

--- a/src/components/form-editor.tsx
+++ b/src/components/form-editor.tsx
@@ -55,7 +55,6 @@ export const FormEditor = ({ viewSetId, moveCallback, moveButtonsDisabled, handl
     const [alertMessage, setAlertMessage] = useState('');
     const [addAlertMessage, setAddAlertMessage] = useState('');
     const [open, setOpen] = useState(false);
-    const [openWarning, setOpenWarning] = useState(true);
     const [deleteAlertMessage, setDeleteAlertMessage] = useState('');
     const [deleteAlertTitle, setDeleteAlertTitle] = useState('');
     const [preventDeleteDialog, setPreventDeleteDialog] = useState(false);
@@ -287,50 +286,52 @@ export const FormEditor = ({ viewSetId, moveCallback, moveButtonsDisabled, handl
                     }
                 </Grid>
 
-                <Grid item xs={3}>
-                    <Tooltip title='Move form left'>
-                        <span>
-                            <IconButton
-                                disabled={visibleTypes.indexOf(viewSetId) === 0 ? true : false || moveButtonsDisabled}
-                                onClick={() => moveForm(viewSetId, 'left')}
-                                aria-label='left' size='medium'>
-                                <ArrowBackRoundedIcon />
-                            </IconButton>
-                        </span>
-                    </Tooltip>
-                    <Tooltip title='Move form right'>
-                        <span>
-                            <IconButton
-                                disabled={visibleTypes.indexOf(viewSetId) === (visibleTypes.length - 1) ? true : false || moveButtonsDisabled}
-                                onClick={() => moveForm(viewSetId, 'right')}
-                                aria-label='right' size='medium'>
-                                <ArrowForwardRoundedIcon />
-                            </IconButton>
-                        </span>
-                    </Tooltip>
-
-                    {moveButtonsDisabled &&
-                        <Collapse in={openWarning}>
-                            <Alert
-                                severity="info"
-                                action={
+                {moveButtonsDisabled ?
+                    (
+                        <Grid item xs={3}>
+                            <Tooltip title='Only forms with an "Add New Record" button can be re-ordered.'>
+                                <span>
                                     <IconButton
-                                        aria-label="close"
-                                        color="inherit"
-                                        size="small"
-                                        onClick={() => {
-                                            setOpenWarning(false);
-                                        }}
-                                    >
-                                        <CloseRoundedIcon fontSize="inherit" />
+                                        disabled={visibleTypes.indexOf(viewSetId) === 0 ? true : false || moveButtonsDisabled}
+                                        onClick={() => moveForm(viewSetId, 'left')}
+                                        aria-label='left' size='medium'>
+                                        <ArrowBackRoundedIcon />
                                     </IconButton>
-                                }
-                            >
-                                Only forms with an "Add New Record" button can be re-ordered.
-                            </Alert>
-                        </Collapse>
-                    }
-                </Grid>
+                                    <IconButton
+                                        disabled={visibleTypes.indexOf(viewSetId) === (visibleTypes.length - 1) ? true : false || moveButtonsDisabled}
+                                        onClick={() => moveForm(viewSetId, 'right')}
+                                        aria-label='right' size='medium'>
+                                        <ArrowForwardRoundedIcon />
+                                    </IconButton>
+                                </span>
+                            </Tooltip>
+                        </Grid>
+                    ) :
+                    (
+                        <Grid item xs={3}>
+                            <Tooltip title='Move form left'>
+                                <span>
+                                    <IconButton
+                                        disabled={visibleTypes.indexOf(viewSetId) === 0 ? true : false || moveButtonsDisabled}
+                                        onClick={() => moveForm(viewSetId, 'left')}
+                                        aria-label='left' size='medium'>
+                                        <ArrowBackRoundedIcon />
+                                    </IconButton>
+                                </span>
+                            </Tooltip>
+                            <Tooltip title='Move form right'>
+                                <span>
+                                    <IconButton
+                                        disabled={visibleTypes.indexOf(viewSetId) === (visibleTypes.length - 1) ? true : false || moveButtonsDisabled}
+                                        onClick={() => moveForm(viewSetId, 'right')}
+                                        aria-label='right' size='medium'>
+                                        <ArrowForwardRoundedIcon />
+                                    </IconButton>
+                                </span>
+                            </Tooltip>
+                        </Grid>
+                    )
+                }
 
                 <Grid item xs={4}>
                     <FormControlLabel

--- a/src/components/form-editor.tsx
+++ b/src/components/form-editor.tsx
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { Grid, Paper, Alert, Stepper, Typography, Step, Button, StepButton, TextField, Dialog, DialogTitle, DialogActions, DialogContent, DialogContentText, Card, InputAdornment, Tooltip, IconButton } from "@mui/material";
+import { Grid, Paper, Alert, Stepper, Typography, Step, Button, StepButton, TextField, Dialog, DialogTitle, DialogActions, DialogContent, DialogContentText, Card, InputAdornment, Tooltip, IconButton, Checkbox, FormControlLabel } from "@mui/material";
 import DeleteIcon from "@mui/icons-material/Delete";
 import EditIcon from '@mui/icons-material/Edit';
 import CloseRoundedIcon from '@mui/icons-material/CloseRounded';
@@ -25,17 +25,18 @@ import { Notebook } from "../state/initial";
 
 export const FormEditor = ({ viewSetId }: { viewSetId: string }) => {
 
+    const visibleTypes = useAppSelector((state: Notebook) => state['ui-specification'].visible_types);
+    const viewsets = useAppSelector((state: Notebook) => state['ui-specification'].viewsets);
     const viewSet = useAppSelector((state: Notebook) => state['ui-specification'].viewsets[viewSetId],
         (left, right) => {
             return shallowEqual(left, right);
         });
-
-    const viewsets = useAppSelector((state: Notebook) => state['ui-specification'].viewsets);
     const views = useAppSelector((state: Notebook) => state['ui-specification'].fviews);
     const fields = useAppSelector((state: Notebook) => state['ui-specification'].fields);
     const dispatch = useAppDispatch();
 
     console.log('FormEditor', viewSetId);
+    console.log('FormEditor visible_types', visibleTypes);
 
     const [activeStep, setActiveStep] = useState(0);
     const [newSectionName, setNewSectionName] = useState('New Section');
@@ -45,6 +46,8 @@ export const FormEditor = ({ viewSetId }: { viewSetId: string }) => {
     const [deleteAlertTitle, setDeleteAlertTitle] = useState('');
     const [preventDeleteDialog, setPreventDeleteDialog] = useState(false);
     const [editMode, setEditMode] = useState(false);
+    const [checked, setChecked] = useState(true);
+    const [initialIndex, setInitialIndex] = useState(visibleTypes.indexOf(viewSetId))
 
     const handleStep = (step: number) => () => {
         setActiveStep(step);
@@ -53,6 +56,11 @@ export const FormEditor = ({ viewSetId }: { viewSetId: string }) => {
     const handleClose = () => {
         setOpen(false);
     };
+
+    const handleChange = (ticked: boolean) => {
+        setChecked(ticked);
+        dispatch({ type: 'ui-specification/formVisibilityUpdated', payload: { viewSetId, ticked, initialIndex } });
+    }
 
     const addNewSection = () => {
         try {
@@ -177,6 +185,19 @@ export const FormEditor = ({ viewSetId }: { viewSetId: string }) => {
                 </Grid>
 
                 <Grid item xs={3}>
+                    <Tooltip arrow title="Tick to include 'Add New Record' button.">
+                        <FormControlLabel
+                            control={<Checkbox
+                                checked={checked}
+                                size="small"
+                                onChange={(e) => handleChange(e.target.checked)}
+                            />}
+                            label="Visible on Top"
+                        />
+                    </Tooltip>
+                </Grid>
+
+                <Grid item xs={3}>
                     <Button variant="text" size="medium" startIcon={<EditIcon />} onClick={() => setEditMode(true)}>
                         Edit form name
                     </Button>
@@ -202,12 +223,9 @@ export const FormEditor = ({ viewSetId }: { viewSetId: string }) => {
                             onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
                                 updateFormLabel(event.target.value);
                             }}
+                            sx={{ '& .MuiInputBase-root': { paddingRight: 0 } }}
                         />
                     }
-                </Grid>
-
-                <Grid item xs={3}>
-
                 </Grid>
 
                 <Grid item xs={3}>

--- a/src/components/section-editor.tsx
+++ b/src/components/section-editor.tsx
@@ -77,7 +77,7 @@ export const SectionEditor = ({ viewSetId, viewId, viewSet, deleteCallback, addC
         }
         else {
             // manually setting the error message
-            setAddAlertMessage('Section '+newSectionName+' already exists in this form.')
+            setAddAlertMessage(`Section ${newSectionName} already exists in this form.`)
         }
     }
 
@@ -146,14 +146,18 @@ export const SectionEditor = ({ viewSetId, viewId, viewSet, deleteCallback, addC
 
                 <Grid item xs={2}>
                     <Tooltip title='Move left'>
-                        <IconButton disabled={viewSet.views.indexOf(viewId) === 0 ? true : false} onClick={() => moveSection('left')} aria-label='left' size='small'>
-                            <ArrowBackRoundedIcon />
-                        </IconButton>
+                        <span>
+                            <IconButton disabled={viewSet.views.indexOf(viewId) === 0 ? true : false} onClick={() => moveSection('left')} aria-label='left' size='small'>
+                                <ArrowBackRoundedIcon />
+                            </IconButton>
+                        </span>
                     </Tooltip>
                     <Tooltip title='Move right'>
-                        <IconButton disabled={viewSet.views.indexOf(viewId) === (viewSet.views.length-1) ? true : false} onClick={() => moveSection('right')} aria-label='right' size='small'>
-                            <ArrowForwardRoundedIcon />
-                        </IconButton>
+                        <span>
+                            <IconButton disabled={viewSet.views.indexOf(viewId) === (viewSet.views.length - 1) ? true : false} onClick={() => moveSection('right')} aria-label='right' size='small'>
+                                <ArrowForwardRoundedIcon />
+                            </IconButton>
+                        </span>
                     </Tooltip>
                 </Grid>
 

--- a/src/components/section-editor.tsx
+++ b/src/components/section-editor.tsx
@@ -67,10 +67,7 @@ export const SectionEditor = ({ viewSetId, viewId, viewSet, deleteCallback, addC
     }
 
     const addNewSection = () => {
-        // run the function to add a new section
-        addCallback(viewSetId, newSectionName);
-
-        // save the returned success status to a variable
+        // run the function to add a new section AND save the returned success status to a variable
         const addSuccess: boolean = addCallback(viewSetId, newSectionName);
 
         // depending on addSuccess, set relevant state variables

--- a/src/components/section-editor.tsx
+++ b/src/components/section-editor.tsx
@@ -12,8 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { Grid, TextField, Button, Dialog, DialogActions, DialogTitle } from "@mui/material";
+import { Grid, TextField, Button, Dialog, DialogActions, DialogTitle, InputAdornment, Tooltip, IconButton } from "@mui/material";
 import DeleteIcon from "@mui/icons-material/Delete";
+import EditIcon from '@mui/icons-material/Edit';
+import CloseRoundedIcon from '@mui/icons-material/CloseRounded';
+import DoneRoundedIcon from '@mui/icons-material/DoneRounded';
 
 import { FieldList } from "./field-list";
 import { useAppSelector, useAppDispatch } from "../state/hooks";
@@ -34,6 +37,7 @@ export const SectionEditor = ({ viewSetId, viewId, deleteCallback }: Props) => {
     console.log('SectionEditor', viewId);
 
     const [open, setOpen] = useState(false);
+    const [editMode, setEditMode] = useState(false);
 
     const updateSectionLabel = (label: string) => {
         dispatch({ type: 'ui-specification/sectionNameUpdated', payload: { viewId, label } });
@@ -50,22 +54,8 @@ export const SectionEditor = ({ viewSetId, viewId, deleteCallback }: Props) => {
 
     return (
         <>
-            <Grid container spacing={2}>
-                <Grid item sm={6} p={2}>
-                    <TextField
-                        fullWidth
-                        required
-                        label="Section Name"
-                        helperText="Name for this section of the form."
-                        name="label"
-                        data-testid="label"
-                        value={fView.label}
-                        onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
-                            updateSectionLabel(event.target.value);
-                        }}
-                    />
-                </Grid>
-                <Grid item sm={6}>
+            <Grid container spacing={2} pb={2}>
+                <Grid item sm={4}>
                     <Button variant="text" color="error" size="small" startIcon={<DeleteIcon />} onClick={() => setOpen(true)}>
                         Delete this section
                     </Button>
@@ -83,6 +73,48 @@ export const SectionEditor = ({ viewSetId, viewId, deleteCallback }: Props) => {
                             <Button onClick={handleClose}>No</Button>
                         </DialogActions>
                     </Dialog>
+                </Grid>
+
+                <Grid item sm={4}>
+                    <Button variant="text" size="small" startIcon={<EditIcon />} onClick={() => setEditMode(true)}>
+                        Edit section name
+                    </Button>
+                    {editMode &&
+                        <TextField
+                            required
+                            size="small"
+                            margin="dense"
+                            label="Section Name"
+                            name="label"
+                            data-testid="label"
+                            InputProps={{
+                                endAdornment: (
+                                    <InputAdornment position="end">
+                                        <Tooltip title="Done">
+                                            <IconButton onClick={() => setEditMode(false)}>
+                                                <DoneRoundedIcon />
+                                            </IconButton>
+                                        </Tooltip>
+                                        <Tooltip title="Close">
+                                            <IconButton onClick={() => setEditMode(false)}>
+                                                <CloseRoundedIcon />
+                                            </IconButton>
+                                        </Tooltip>
+                                    </InputAdornment>
+                                ),
+                            }}
+                            value={fView.label}
+                            onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
+                                updateSectionLabel(event.target.value);
+                            }}
+                            sx={{ '& .MuiInputBase-root': { paddingRight: 0 } }}
+                        />
+                    }
+                </Grid>
+
+
+                <Grid item sm={4}>
+                /* move left and right buttons will be here */
                 </Grid>
             </Grid>
 

--- a/src/components/section-editor.tsx
+++ b/src/components/section-editor.tsx
@@ -35,10 +35,11 @@ type Props = {
         label: string;
     }
     deleteCallback: (viewSetID: string, viewID: string) => void,
+    addCallback: (viewSetID: string, label: string) => boolean,
     moveCallback: (viewSetID: string, viewID: string, moveDirection: 'left' | 'right') => void
 };
 
-export const SectionEditor = ({ viewSetId, viewId, viewSet, deleteCallback, moveCallback }: Props) => {
+export const SectionEditor = ({ viewSetId, viewId, viewSet, deleteCallback, addCallback, moveCallback }: Props) => {
 
     const fView = useAppSelector((state: Notebook) => state['ui-specification'].fviews[viewId]);
     const dispatch = useAppDispatch();
@@ -66,13 +67,20 @@ export const SectionEditor = ({ viewSetId, viewId, viewSet, deleteCallback, move
     }
 
     const addNewSection = () => {
-        try {
-            dispatch({ type: 'ui-specification/sectionAdded', payload: { viewSetId: viewSetId, sectionLabel: newSectionName } });
+        // run the function to add a new section
+        addCallback(viewSetId, newSectionName);
+
+        // save the returned success status to a variable
+        const addSuccess: boolean = addCallback(viewSetId, newSectionName);
+
+        // depending on addSuccess, set relevant state variables
+        if (addSuccess) {
             setAddMode(false);
             setAddAlertMessage('');
-        } catch (error: unknown) {
-            error instanceof Error &&
-                setAddAlertMessage(error.message);
+        }
+        else {
+            // manually setting the error message
+            setAddAlertMessage('Section '+newSectionName+' already exists in this form.')
         }
     }
 
@@ -139,7 +147,7 @@ export const SectionEditor = ({ viewSetId, viewId, viewSet, deleteCallback, move
                     }
                 </Grid>
 
-                <Grid item xs={3}>
+                <Grid item xs={2}>
                     <Tooltip title='Move left'>
                         <IconButton disabled={viewSet.views.indexOf(viewId) === 0 ? true : false} onClick={() => moveSection('left')} aria-label='left' size='small'>
                             <ArrowBackRoundedIcon />
@@ -152,7 +160,7 @@ export const SectionEditor = ({ viewSetId, viewId, viewSet, deleteCallback, move
                     </Tooltip>
                 </Grid>
 
-                <Grid item xs={3}>
+                <Grid item xs={4}>
                     <Button variant="text" size="small" startIcon={<AddCircleOutlineRoundedIcon />} onClick={() => setAddMode(true)}>
                         Add new section
                     </Button>

--- a/src/components/section-editor.tsx
+++ b/src/components/section-editor.tsx
@@ -87,10 +87,10 @@ export const SectionEditor = ({ viewSetId, viewId, viewSet, deleteCallback, addC
 
     return (
         <>
-            <Grid container spacing={2} pb={2}>
-                <Grid item xs={3}>
+            <Grid container spacing={1.75} mb={2}>
+                <Grid item xs={2}>
                     <Button variant="text" color="error" size="small" startIcon={<DeleteRoundedIcon />} onClick={() => setOpen(true)}>
-                        Delete this section
+                        Delete section
                     </Button>
                     <Dialog
                         open={open}
@@ -123,12 +123,12 @@ export const SectionEditor = ({ viewSetId, viewId, viewSet, deleteCallback, addC
                                 endAdornment: (
                                     <InputAdornment position="end">
                                         <Tooltip title="Done">
-                                            <IconButton onClick={() => setEditMode(false)}>
+                                            <IconButton size="small" onClick={() => setEditMode(false)}>
                                                 <DoneRoundedIcon />
                                             </IconButton>
                                         </Tooltip>
                                         <Tooltip title="Close">
-                                            <IconButton onClick={() => setEditMode(false)}>
+                                            <IconButton size="small" onClick={() => setEditMode(false)}>
                                                 <CloseRoundedIcon />
                                             </IconButton>
                                         </Tooltip>
@@ -145,14 +145,14 @@ export const SectionEditor = ({ viewSetId, viewId, viewSet, deleteCallback, addC
                 </Grid>
 
                 <Grid item xs={2}>
-                    <Tooltip title='Move left'>
+                    <Tooltip title='Move section left'>
                         <span>
                             <IconButton disabled={viewSet.views.indexOf(viewId) === 0 ? true : false} onClick={() => moveSection('left')} aria-label='left' size='small'>
                                 <ArrowBackRoundedIcon />
                             </IconButton>
                         </span>
                     </Tooltip>
-                    <Tooltip title='Move right'>
+                    <Tooltip title='Move section right'>
                         <span>
                             <IconButton disabled={viewSet.views.indexOf(viewId) === (viewSet.views.length - 1) ? true : false} onClick={() => moveSection('right')} aria-label='right' size='small'>
                                 <ArrowForwardRoundedIcon />
@@ -161,7 +161,7 @@ export const SectionEditor = ({ viewSetId, viewId, viewSet, deleteCallback, addC
                     </Tooltip>
                 </Grid>
 
-                <Grid item xs={4}>
+                <Grid item xs={3}>
                     <Button variant="text" size="small" startIcon={<AddCircleOutlineRoundedIcon />} onClick={() => setAddMode(true)}>
                         Add new section
                     </Button>
@@ -178,12 +178,12 @@ export const SectionEditor = ({ viewSetId, viewId, viewSet, deleteCallback, addC
                                 endAdornment: (
                                     <InputAdornment position="end">
                                         <Tooltip title="Add">
-                                            <IconButton onClick={addNewSection}>
+                                            <IconButton size="small" onClick={addNewSection}>
                                                 <AddRoundedIcon />
                                             </IconButton>
                                         </Tooltip>
                                         <Tooltip title="Close">
-                                            <IconButton onClick={() => {
+                                            <IconButton size="small" onClick={() => {
                                                 setAddMode(false);
                                                 setAddAlertMessage('');
                                             }}>

--- a/src/components/section-editor.tsx
+++ b/src/components/section-editor.tsx
@@ -113,34 +113,39 @@ export const SectionEditor = ({ viewSetId, viewId, viewSet, deleteCallback, addC
                         Edit section name
                     </Button>
                     {editMode &&
-                        <TextField
-                            size="small"
-                            margin="dense"
-                            label="Section Name"
-                            name="label"
-                            data-testid="label"
-                            InputProps={{
-                                endAdornment: (
-                                    <InputAdornment position="end">
-                                        <Tooltip title="Done">
-                                            <IconButton size="small" onClick={() => setEditMode(false)}>
-                                                <DoneRoundedIcon />
-                                            </IconButton>
-                                        </Tooltip>
-                                        <Tooltip title="Close">
-                                            <IconButton size="small" onClick={() => setEditMode(false)}>
-                                                <CloseRoundedIcon />
-                                            </IconButton>
-                                        </Tooltip>
-                                    </InputAdornment>
-                                ),
-                            }}
-                            value={fView.label}
-                            onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
-                                updateSectionLabel(event.target.value);
-                            }}
-                            sx={{ '& .MuiInputBase-root': { paddingRight: 0 } }}
-                        />
+                        <form onSubmit={(e: React.FormEvent<HTMLFormElement>) => {
+                            e.preventDefault();
+                            setEditMode(false);
+                        }}>
+                            <TextField
+                                size="small"
+                                margin="dense"
+                                label="Section Name"
+                                name="label"
+                                data-testid="label"
+                                InputProps={{
+                                    endAdornment: (
+                                        <InputAdornment position="end">
+                                            <Tooltip title="Done">
+                                                <IconButton size="small" type="submit">
+                                                    <DoneRoundedIcon />
+                                                </IconButton>
+                                            </Tooltip>
+                                            <Tooltip title="Close">
+                                                <IconButton size="small" onClick={() => setEditMode(false)}>
+                                                    <CloseRoundedIcon />
+                                                </IconButton>
+                                            </Tooltip>
+                                        </InputAdornment>
+                                    ),
+                                }}
+                                value={fView.label}
+                                onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
+                                    updateSectionLabel(event.target.value);
+                                }}
+                                sx={{ '& .MuiInputBase-root': { paddingRight: 0 } }}
+                            />
+                        </form>
                     }
                 </Grid>
 
@@ -166,39 +171,44 @@ export const SectionEditor = ({ viewSetId, viewId, viewSet, deleteCallback, addC
                         Add new section
                     </Button>
                     {addMode &&
-                        <TextField
-                            required
-                            fullWidth
-                            size="small"
-                            margin="dense"
-                            label="New Section Name"
-                            name="sectionName"
-                            data-testid="sectionName"
-                            InputProps={{
-                                endAdornment: (
-                                    <InputAdornment position="end">
-                                        <Tooltip title="Add">
-                                            <IconButton size="small" onClick={addNewSection}>
-                                                <AddRoundedIcon />
-                                            </IconButton>
-                                        </Tooltip>
-                                        <Tooltip title="Close">
-                                            <IconButton size="small" onClick={() => {
-                                                setAddMode(false);
-                                                setAddAlertMessage('');
-                                            }}>
-                                                <CloseRoundedIcon />
-                                            </IconButton>
-                                        </Tooltip>
-                                    </InputAdornment>
-                                ),
-                            }}
-                            value={newSectionName}
-                            onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
-                                setNewSectionName(event.target.value);
-                            }}
-                            sx={{ '& .MuiInputBase-root': { paddingRight: 0 } }}
-                        />
+                        <form onSubmit={(e: React.FormEvent<HTMLFormElement>) => {
+                            e.preventDefault();
+                            addNewSection();
+                        }}>
+                            <TextField
+                                required
+                                fullWidth
+                                size="small"
+                                margin="dense"
+                                label="New Section Name"
+                                name="sectionName"
+                                data-testid="sectionName"
+                                InputProps={{
+                                    endAdornment: (
+                                        <InputAdornment position="end">
+                                            <Tooltip title="Add">
+                                                <IconButton size="small" type="submit">
+                                                    <AddRoundedIcon />
+                                                </IconButton>
+                                            </Tooltip>
+                                            <Tooltip title="Close">
+                                                <IconButton size="small" onClick={() => {
+                                                    setAddMode(false);
+                                                    setAddAlertMessage('');
+                                                }}>
+                                                    <CloseRoundedIcon />
+                                                </IconButton>
+                                            </Tooltip>
+                                        </InputAdornment>
+                                    ),
+                                }}
+                                value={newSectionName}
+                                onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
+                                    setNewSectionName(event.target.value);
+                                }}
+                                sx={{ '& .MuiInputBase-root': { paddingRight: 0 } }}
+                            />
+                        </form>
                     }
                     {addAlertMessage && <Alert severity="error">{addAlertMessage}</Alert>}
                 </Grid>

--- a/src/components/section-editor.tsx
+++ b/src/components/section-editor.tsx
@@ -12,11 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { Grid, TextField, Button, Dialog, DialogActions, DialogTitle, InputAdornment, Tooltip, IconButton } from "@mui/material";
-import DeleteIcon from "@mui/icons-material/Delete";
-import EditIcon from '@mui/icons-material/Edit';
+import { Grid, TextField, Button, Dialog, DialogActions, DialogTitle, InputAdornment, Tooltip, IconButton, Alert } from "@mui/material";
+import DeleteRoundedIcon from '@mui/icons-material/DeleteRounded';
+import EditRoundedIcon from '@mui/icons-material/EditRounded';
 import CloseRoundedIcon from '@mui/icons-material/CloseRounded';
 import DoneRoundedIcon from '@mui/icons-material/DoneRounded';
+import AddRoundedIcon from '@mui/icons-material/AddRounded';
+import AddCircleOutlineRoundedIcon from '@mui/icons-material/AddCircleOutlineRounded';
 
 import { FieldList } from "./field-list";
 import { useAppSelector, useAppDispatch } from "../state/hooks";
@@ -38,13 +40,27 @@ export const SectionEditor = ({ viewSetId, viewId, deleteCallback }: Props) => {
 
     const [open, setOpen] = useState(false);
     const [editMode, setEditMode] = useState(false);
-
-    const updateSectionLabel = (label: string) => {
-        dispatch({ type: 'ui-specification/sectionNameUpdated', payload: { viewId, label } });
-    }
+    const [addMode, setAddMode] = useState(false);
+    const [newSectionName, setNewSectionName] = useState('New Section');
+    const [alertMessage, setAlertMessage] = useState('');
 
     const handleClose = () => {
         setOpen(false);
+    }
+
+    const addNewSection = () => {
+        try {
+            dispatch({ type: 'ui-specification/formSectionAdded', payload: { viewSetId: viewSetId, sectionLabel: newSectionName } });
+            setAddMode(false);
+            setAlertMessage('');
+        } catch (error: unknown) {
+            error instanceof Error &&
+                setAlertMessage(error.message);
+        }
+    }
+
+    const updateSectionLabel = (label: string) => {
+        dispatch({ type: 'ui-specification/sectionNameUpdated', payload: { viewId, label } });
     }
 
     const deleteSection = () => {
@@ -55,8 +71,8 @@ export const SectionEditor = ({ viewSetId, viewId, deleteCallback }: Props) => {
     return (
         <>
             <Grid container spacing={2} pb={2}>
-                <Grid item sm={4}>
-                    <Button variant="text" color="error" size="small" startIcon={<DeleteIcon />} onClick={() => setOpen(true)}>
+                <Grid item xs={3}>
+                    <Button variant="text" color="error" size="small" startIcon={<DeleteRoundedIcon />} onClick={() => setOpen(true)}>
                         Delete this section
                     </Button>
                     <Dialog
@@ -75,13 +91,12 @@ export const SectionEditor = ({ viewSetId, viewId, deleteCallback }: Props) => {
                     </Dialog>
                 </Grid>
 
-                <Grid item sm={4}>
-                    <Button variant="text" size="small" startIcon={<EditIcon />} onClick={() => setEditMode(true)}>
+                <Grid item xs={3}>
+                    <Button variant="text" size="small" startIcon={<EditRoundedIcon />} onClick={() => setEditMode(true)}>
                         Edit section name
                     </Button>
                     {editMode &&
                         <TextField
-                            required
                             size="small"
                             margin="dense"
                             label="Section Name"
@@ -112,9 +127,50 @@ export const SectionEditor = ({ viewSetId, viewId, deleteCallback }: Props) => {
                     }
                 </Grid>
 
-
-                <Grid item sm={4}>
+                <Grid item xs={3}>
                 /* move left and right buttons will be here */
+                </Grid>
+
+                <Grid item xs={3}>
+                    <Button variant="text" size="small" startIcon={<AddCircleOutlineRoundedIcon />} onClick={() => setAddMode(true)}>
+                        Add new section
+                    </Button>
+                    {addMode &&
+                        <TextField
+                            required
+                            fullWidth
+                            size="small"
+                            margin="dense"
+                            label="New Section Name"
+                            name="sectionName"
+                            data-testid="sectionName"
+                            InputProps={{
+                                endAdornment: (
+                                    <InputAdornment position="end">
+                                        <Tooltip title="Add">
+                                            <IconButton onClick={addNewSection}>
+                                                <AddRoundedIcon />
+                                            </IconButton>
+                                        </Tooltip>
+                                        <Tooltip title="Close">
+                                            <IconButton onClick={() => {
+                                                setAddMode(false);
+                                                setAlertMessage('');
+                                            }}>
+                                                <CloseRoundedIcon />
+                                            </IconButton>
+                                        </Tooltip>
+                                    </InputAdornment>
+                                ),
+                            }}
+                            value={newSectionName}
+                            onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
+                                setNewSectionName(event.target.value);
+                            }}
+                            sx={{ '& .MuiInputBase-root': { paddingRight: 0 } }}
+                        />
+                    }
+                    {alertMessage && <Alert severity="error">{alertMessage}</Alert>}
                 </Grid>
             </Grid>
 

--- a/src/state/uiSpec-reducer.ts
+++ b/src/state/uiSpec-reducer.ts
@@ -318,6 +318,46 @@ export const uiSpecificationReducer = createSlice({
                 state.visible_types = newVisibleTypes;
             }
         },
+        viewSetMoved: (state: NotebookUISpec,
+            action: PayloadAction<{ viewSetId: string, direction: 'left' | 'right' }>) => {
+
+            const { viewSetId, direction } = action.payload;
+
+            // get viewsets obj in array format [[key, value]]
+            const viewSetsList = Object.entries(state.viewsets);
+
+            // re-order the array
+            for (let i = 0; i < viewSetsList.length; i++) {
+                if (viewSetsList[i][0] == viewSetId) {
+                    if (direction === 'left') {
+                        if (i > 0) {
+                            const tmp = viewSetsList[i - 1];
+                            viewSetsList[i - 1] = viewSetsList[i];
+                            viewSetsList[i] = tmp;
+                        }
+                    } else {
+                        if (i < viewSetsList.length - 1) {
+                            const tmp = viewSetsList[i + 1];
+                            viewSetsList[i + 1] = viewSetsList[i];
+                            viewSetsList[i] = tmp;
+                        }
+                    }
+                    // we're done
+                    break;
+                }
+            }
+
+            // transform array of entries back into object & update state
+            // doesn't work
+            const newViewsets = Object.fromEntries(viewSetsList);
+            state.viewsets = newViewsets
+
+            // doesn't work
+            // state = { ...state, viewsets: newViewsets }
+
+            // doesn't work
+            // return {...state, viewsets: Object.fromEntries(viewSetsList)}
+        },
         viewSetRenamed: (state: NotebookUISpec,
             action: PayloadAction<{ viewSetId: string, label: string }>) => {
             const { viewSetId, label } = action.payload;

--- a/src/state/uiSpec-reducer.ts
+++ b/src/state/uiSpec-reducer.ts
@@ -263,7 +263,21 @@ export const uiSpecificationReducer = createSlice({
             console.log('updating form name', viewSetId, 'with', label);
             if (viewSetId in state.viewsets) {
                 state.viewsets[viewSetId].label = label;
-            } 
+            }
+        },
+        formVisibilityUpdated: (state: NotebookUISpec,
+            action: PayloadAction<{ viewSetId: string, ticked: boolean, initialIndex: number }>) => {
+            const { viewSetId, ticked, initialIndex } = action.payload;
+
+            if (!ticked) {
+                const newVisibleTypes = state.visible_types.filter((visibleType) => visibleType !== viewSetId);
+                state.visible_types = newVisibleTypes;
+
+                console.log('after removing', viewSetId, ', visible_types is now', state.visible_types)
+            }
+            else {
+                state.visible_types.splice(initialIndex, 0, viewSetId);
+            }
         },
         formSectionAdded: (state: NotebookUISpec,
             action: PayloadAction<{ viewSetId: string, sectionLabel: string }>) => {

--- a/src/state/uiSpec-reducer.ts
+++ b/src/state/uiSpec-reducer.ts
@@ -286,7 +286,7 @@ export const uiSpecificationReducer = createSlice({
             const formID = slugify(formName);
             // add this to the viewsets
             if (formID in state.viewsets) {
-                throw new Error(`Form ${formID} already exists in notebook`);
+                throw new Error(`Form ${formID} already exists in notebook.`);
             } else {
                 state.viewsets[formID] = newViewSet;
                 state.visible_types.push(formID);
@@ -323,40 +323,29 @@ export const uiSpecificationReducer = createSlice({
 
             const { viewSetId, direction } = action.payload;
 
-            // get viewsets obj in array format [[key, value]]
-            const viewSetsList = Object.entries(state.viewsets);
-
+            const formsList = state.visible_types;
             // re-order the array
-            for (let i = 0; i < viewSetsList.length; i++) {
-                if (viewSetsList[i][0] == viewSetId) {
+            for (let i = 0; i < formsList.length; i++) {
+                if (formsList[i] == viewSetId) {
                     if (direction === 'left') {
                         if (i > 0) {
-                            const tmp = viewSetsList[i - 1];
-                            viewSetsList[i - 1] = viewSetsList[i];
-                            viewSetsList[i] = tmp;
+                            const tmp = formsList[i - 1];
+                            formsList[i - 1] = formsList[i];
+                            formsList[i] = tmp;
                         }
                     } else {
-                        if (i < viewSetsList.length - 1) {
-                            const tmp = viewSetsList[i + 1];
-                            viewSetsList[i + 1] = viewSetsList[i];
-                            viewSetsList[i] = tmp;
+                        if (i < formsList.length - 1) {
+                            const tmp = formsList[i + 1];
+                            formsList[i + 1] = formsList[i];
+                            formsList[i] = tmp;
                         }
                     }
                     // we're done
                     break;
                 }
             }
-
-            // transform array of entries back into object & update state
-            // doesn't work
-            const newViewsets = Object.fromEntries(viewSetsList);
-            state.viewsets = newViewsets
-
-            // doesn't work
-            // state = { ...state, viewsets: newViewsets }
-
-            // doesn't work
-            // return {...state, viewsets: Object.fromEntries(viewSetsList)}
+            // update state 
+            state.visible_types = formsList;
         },
         viewSetRenamed: (state: NotebookUISpec,
             action: PayloadAction<{ viewSetId: string, label: string }>) => {
@@ -370,6 +359,8 @@ export const uiSpecificationReducer = createSlice({
             action: PayloadAction<{ viewSetId: string, ticked: boolean, initialIndex: number }>) => {
             const { viewSetId, ticked, initialIndex } = action.payload;
 
+            console.log('initial index in reducer ', initialIndex)
+
             if (!ticked) {
                 const newVisibleTypes = state.visible_types.filter((visibleType) => visibleType !== viewSetId);
                 state.visible_types = newVisibleTypes;
@@ -377,7 +368,11 @@ export const uiSpecificationReducer = createSlice({
                 console.log('after removing', viewSetId, ', visible_types is now', state.visible_types)
             }
             else {
-                state.visible_types.splice(initialIndex, 0, viewSetId);
+                // currently re-adding the form back at the end of the visible_types array because 
+                // I can't figure out how to store the initial index correctly (keeps being -1, which obviously won't work)
+                state.visible_types.splice(state.visible_types.length, 0, viewSetId);
+
+                console.log('after re-adding', viewSetId, 'visible_types is now', state.visible_types)
             }
         },
     }

--- a/src/state/uiSpec-reducer.ts
+++ b/src/state/uiSpec-reducer.ts
@@ -55,7 +55,6 @@ export const uiSpecificationReducer = createSlice({
         fieldUpdated: (state: NotebookUISpec,
             action: PayloadAction<{ fieldName: string, newField: FieldType }>) => {
             const { fieldName, newField } = action.payload;
-            console.log('updating field', fieldName, 'with', newField);
             if (fieldName in state.fields) {
                 state.fields[fieldName] = newField;
             } else {
@@ -116,8 +115,6 @@ export const uiSpecificationReducer = createSlice({
                         break;
                     }
                 }
-                console.log('renamed field', fieldName, 'to', newFieldName, 'in view', viewId);
-                console.log(viewFields);
             } else {
                 throw new Error(`Cannot rename unknown field ${fieldName} via fieldRenamed action`);
             }
@@ -130,7 +127,6 @@ export const uiSpecificationReducer = createSlice({
                 viewSetId: string
             }>) => {
             const { fieldName, fieldType, viewId, viewSetId } = action.payload;
-            console.log('adding field', fieldName, 'to', viewSetId, '-', viewId, 'type', fieldType);
 
             const newField: FieldType = getFieldSpec(fieldType);
 
@@ -186,7 +182,6 @@ export const uiSpecificationReducer = createSlice({
                 fieldLabel = slugify(fieldName + ' ' + N);
                 N += 1;
             }
-            console.log('adding field', fieldLabel, 'to', viewId, 'as', newField);
             newField['component-parameters'].name = fieldLabel;
             // add to fields and to the fview section
             state.fields[fieldLabel] = newField;
@@ -208,7 +203,6 @@ export const uiSpecificationReducer = createSlice({
         sectionRenamed: (state: NotebookUISpec,
             action: PayloadAction<{ viewId: string, label: string }>) => {
             const { viewId, label } = action.payload;
-            console.log('updating section name', viewId, 'with', label);
             if (viewId in state.fviews) {
                 state.fviews[viewId].label = label;
             } else {
@@ -350,29 +344,22 @@ export const uiSpecificationReducer = createSlice({
         viewSetRenamed: (state: NotebookUISpec,
             action: PayloadAction<{ viewSetId: string, label: string }>) => {
             const { viewSetId, label } = action.payload;
-            console.log('updating form name', viewSetId, 'with', label);
             if (viewSetId in state.viewsets) {
                 state.viewsets[viewSetId].label = label;
             }
         },
         formVisibilityUpdated: (state: NotebookUISpec,
             action: PayloadAction<{ viewSetId: string, ticked: boolean, initialIndex: number }>) => {
-            const { viewSetId, ticked, initialIndex } = action.payload;
-
-            console.log('initial index in reducer ', initialIndex)
+            const { viewSetId, ticked } = action.payload;
 
             if (!ticked) {
                 const newVisibleTypes = state.visible_types.filter((visibleType) => visibleType !== viewSetId);
                 state.visible_types = newVisibleTypes;
-
-                console.log('after removing', viewSetId, ', visible_types is now', state.visible_types)
             }
             else {
                 // currently re-adding the form back at the end of the visible_types array because 
                 // I can't figure out how to store the initial index correctly (keeps being -1, which obviously won't work)
                 state.visible_types.splice(state.visible_types.length, 0, viewSetId);
-
-                console.log('after re-adding', viewSetId, 'visible_types is now', state.visible_types)
             }
         },
     }

--- a/src/state/uiSpec-reducer.ts
+++ b/src/state/uiSpec-reducer.ts
@@ -257,6 +257,14 @@ export const uiSpecificationReducer = createSlice({
                 state.visible_types = newVisibleTypes;
             }
         },
+        formNameUpdated: (state: NotebookUISpec,
+            action: PayloadAction<{ viewSetId: string, label: string }>) => {
+            const { viewSetId, label } = action.payload;
+            console.log('updating form name', viewSetId, 'with', label);
+            if (viewSetId in state.viewsets) {
+                state.viewsets[viewSetId].label = label;
+            } 
+        },
         formSectionAdded: (state: NotebookUISpec,
             action: PayloadAction<{ viewSetId: string, sectionLabel: string }>) => {
             const { viewSetId, sectionLabel } = action.payload;

--- a/src/state/uiSpec-reducer.ts
+++ b/src/state/uiSpec-reducer.ts
@@ -237,11 +237,11 @@ export const uiSpecificationReducer = createSlice({
             if (viewSetId in state.viewsets) {
                 // working copy of the section names ('views') part of the form that is to be removed
                 const viewSetViews: string[] = state.viewsets[viewSetId].views
-                viewSetViews.map((view) => {
+                viewSetViews.forEach((view) => {
                     if (view in state.fviews) {
                         // working copy of the field names ('fields') part of the section that is part of the form that is to be removed
                         const viewFields: string[] = state.fviews[view].fields
-                        viewFields.map((formField) => {
+                        viewFields.forEach((formField) => {
                             if (formField in state.fields) {
                                 // remove the fields in 'fields' belonging to their respective sections in the form
                                 delete state.fields[formField]
@@ -300,7 +300,7 @@ export const uiSpecificationReducer = createSlice({
             if (viewID in state.fviews) {
                 // working copy of the field names ('fields') part of the section that is to be removed
                 const sectionFields: string[] = state.fviews[viewID].fields
-                sectionFields.map((field) => {
+                sectionFields.forEach((field) => {
                     if (field in state.fields) {
                         // remove the fields in 'fields' belonging to the section 
                         delete state.fields[field];


### PR DESCRIPTION
# Issues #20 + #21 + #23
This PR adds 4 options to the form (& section) toolbar and updates the overall UI.

## Summary

- Updated the UI to make the separation between forms and sections clearer, and to maintain consistency between the form and section toolbars.
- 'Add a Section' action has been moved up to the section toolbar.
- The following is now possible on enter: adding a new section or form, editing a section or form name.
- A user can now edit the name of a form. (**Note**: Following from this, user feedback when deleting a form used in a related field has been updated to use form and section labels instead of names.)
- A user can now move sections around within a form. Depending on which section they are in, the left or right arrow button becomes disabled as well. Further, the stepper jumps intuitively when a section is moved.
- A user can now move forms around. Similarly to the section move buttons, the left or right arrow becomes disabled when the user is in the first or last form. Further, the tab indicator follows the current form/tab the user is in when it is moved.
- A user can now (un)tick a checkbox to indicate whether a form should include an 'Add New Record' button. If not, then the form is moved to the end of all the tabs and becomes unmovable (both left and right arrows are disabled and there's a note explaining to the user why). The unmovable tabs are in orange, while the default ones are in green. The logic for allowing a user to untick the checkbox includes error validation for some cases (I'm not sure this is extensive).

The cases include:
1. There is only one form in the viewset; 
2. There are multiple forms in the viewset, but only one in the visible_types array; and 
3. There are multiple forms in the viewset, but due to just having deleted the form that was in visible_types, none of the remaining forms are in the visible_types array. (**Note**: Is this case even valid? Should this be prevented when trying to delete a form?)