### PR TITLE
mdxeditor source option

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@emotion/react": "^11.11.1",
         "@emotion/styled": "^11.11.0",
         "@lexical/react": "^0.12.4",
-        "@mdxeditor/editor": "^1.11.4",
+        "@mdxeditor/editor": "^1.13.0",
         "@mui/icons-material": "^5.14.3",
         "@mui/lab": "^5.0.0-alpha.137",
         "@mui/material": "^5.14.2",
@@ -1311,9 +1311,9 @@
       }
     },
     "node_modules/@mdxeditor/editor": {
-      "version": "1.11.4",
-      "resolved": "https://registry.npmjs.org/@mdxeditor/editor/-/editor-1.11.4.tgz",
-      "integrity": "sha512-kAu8ipkRcmPb5L7NxAlUxzrs+GsHpfzKpUh1h9nhxfAlXEzW0mFo0z90o9+cDu9z4qAqmszEY1Fy4Sjqm3RWig==",
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/@mdxeditor/editor/-/editor-1.13.0.tgz",
+      "integrity": "sha512-WKEg+WYVtH+zcoJHzyXXtLV2qQ6cdo+nDJ508Yq7n1XU2GMsmlObVUNd9NqLi3FNa0JRUMEgybHR8eaYAqcyiA==",
       "dependencies": {
         "@codemirror/lang-markdown": "^6.2.1",
         "@codemirror/merge": "^6.1.3",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "@emotion/react": "^11.11.1",
     "@emotion/styled": "^11.11.0",
     "@lexical/react": "^0.12.4",
-    "@mdxeditor/editor": "^1.11.4",
+    "@mdxeditor/editor": "^1.13.0",
     "@mui/icons-material": "^5.14.3",
     "@mui/lab": "^5.0.0-alpha.137",
     "@mui/material": "^5.14.2",

--- a/src/App.css
+++ b/src/App.css
@@ -9,8 +9,9 @@
 }
 
 .mdxEditor {
-  border: 1px solid #c4c4c4;
+  /* border: 1px solid #c4c4c4;
   border-radius: 3px;
-  min-height: 12.5em;
+  min-height: 12.5em; */
+  /* border-bottom: 1px solid #c4c4c4; */
   font-family: 'Open Sans', sans-serif;
 }

--- a/src/App.css
+++ b/src/App.css
@@ -9,9 +9,5 @@
 }
 
 .mdxEditor {
-  /* border: 1px solid #c4c4c4;
-  border-radius: 3px;
-  min-height: 12.5em; */
-  /* border-bottom: 1px solid #c4c4c4; */
   font-family: 'Open Sans', sans-serif;
 }

--- a/src/components/Fields/RichTextEditor.tsx
+++ b/src/components/Fields/RichTextEditor.tsx
@@ -12,34 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { Grid, FormHelperText, Alert, Card } from "@mui/material";
+import { Grid } from "@mui/material";
 import { useAppSelector, useAppDispatch } from "../../state/hooks";
-import { useRef, Suspense, useState } from "react";
-
-import '@mdxeditor/editor/style.css'
-
-// importing the editor and the plugin from their full paths
-import { MDXEditor } from '@mdxeditor/editor/MDXEditor';
-import { MDXEditorMethods, MdastImportVisitor, Separator, realmPlugin, system } from '@mdxeditor/editor';
-import { toolbarPlugin } from '@mdxeditor/editor/plugins/toolbar';
-import { headingsPlugin } from '@mdxeditor/editor/plugins/headings';
-import { listsPlugin } from '@mdxeditor/editor/plugins/lists';
-import { quotePlugin } from '@mdxeditor/editor/plugins/quote';
-import { thematicBreakPlugin } from '@mdxeditor/editor/plugins/thematic-break';
-import { markdownShortcutPlugin } from '@mdxeditor/editor/plugins/markdown-shortcut';
-import { tablePlugin } from '@mdxeditor/editor/plugins/table';
-import { diffSourcePlugin } from '@mdxeditor/editor/plugins/diff-source';
-import { linkPlugin } from '@mdxeditor/editor/plugins/link';
-
-// importing the desired toolbar toggle components
-import { UndoRedo } from '@mdxeditor/editor/plugins/toolbar/components/UndoRedo';
-import { BoldItalicUnderlineToggles } from '@mdxeditor/editor/plugins/toolbar/components/BoldItalicUnderlineToggles';
-import { BlockTypeSelect } from '@mdxeditor/editor/plugins/toolbar/components/BlockTypeSelect';
-import { ListsToggle } from '@mdxeditor/editor/plugins/toolbar/components/ListsToggle';
-import { InsertTable } from '@mdxeditor/editor/plugins/toolbar/components/InsertTable';
-import { DiffSourceToggleWrapper } from '@mdxeditor/editor/plugins/toolbar/components/DiffSourceToggleWrapper';
-
+import { useRef } from "react";
+import { MDXEditorMethods } from '@mdxeditor/editor';
 import { FieldType, Notebook } from "../../state/initial";
+import { MdxEditor } from "../mdx-editor";
 
 
 export const RichTextEditor = ({ fieldName }: { fieldName: string }) => {
@@ -48,8 +26,6 @@ export const RichTextEditor = ({ fieldName }: { fieldName: string }) => {
     const dispatch = useAppDispatch();
 
     const initContent = field['component-parameters'].content || "";
-
-    const [errorMessage, setErrorMessage] = useState('');
     const ref = useRef<MDXEditorMethods>(null);
 
     const updateField = (fieldName: string, newField: FieldType) => {
@@ -73,74 +49,15 @@ export const RichTextEditor = ({ fieldName }: { fieldName: string }) => {
     const updateProperty = (prop: string, value: string | undefined) => {
         const newState = { ...state, [prop]: value };
         updateFieldFromState(newState);
-        setErrorMessage('');
     };
 
-    /*
-        The following is taken from and inspired by: 
-        https://github.com/mdx-editor/editor/issues/202#issuecomment-1827182167 & 
-        https://github.com/mdx-editor/editor/issues/95#issuecomment-1755320066 
-    */
-    const catchAllVisitor: MdastImportVisitor<any> = {
-        testNode: () => true,
-        visitNode: ({ mdastNode, actions }) => {
-            // deviating from the example shown in the second link,
-            // for now, I'm simply showing an error message
-            setErrorMessage(`Sorry, we currently do not support the markdown ${mdastNode?.type} option. 
-                What you have just written was automatically removed. Please continue carefully.`);
-        }
-    };
-
-    const [catchAllPlugin] = realmPlugin({
-        id: "catchAll",
-        systemSpec: system(() => ({})),
-        init: (realm) => {
-            realm.pubKey("addImportVisitor", catchAllVisitor);
-        }
-    });
 
     return (
-        <Grid container xs={12} sm={8} sx={{ m: 'auto' }}>
-            <Grid item xs={12}>
-                <Suspense fallback={<div>Loading...</div>}>
-                    {errorMessage && <Alert severity="error">{errorMessage}</Alert>}
-                    <Card variant="outlined">
-                        <MDXEditor
-                            markdown={initContent}
-                            plugins={[
-                                headingsPlugin(),
-                                listsPlugin(),
-                                quotePlugin(),
-                                thematicBreakPlugin(),
-                                markdownShortcutPlugin(),
-                                tablePlugin(),
-                                diffSourcePlugin({ diffMarkdown: initContent }),
-                                linkPlugin(),
-                                toolbarPlugin({
-                                    toolbarContents: () => (
-                                        <DiffSourceToggleWrapper>
-                                            <UndoRedo />
-                                            <Separator />
-                                            <BoldItalicUnderlineToggles />
-                                            <Separator />
-                                            <BlockTypeSelect />
-                                            <Separator />
-                                            <ListsToggle />
-                                            <Separator />
-                                            <InsertTable />
-                                        </DiffSourceToggleWrapper>
-                                    )
-                                }),
-                                catchAllPlugin(),
-                            ]}
-                            ref={ref}
-                            onChange={() => updateProperty('content', ref.current?.getMarkdown())}
-                            contentEditableClassName="mdxEditor"
-                        />
-                    </Card>
-                </Suspense>
-                <FormHelperText>Use this editor to add rich text to your notebook.</FormHelperText>
-            </Grid>
+        <Grid container item xs={12} sm={8} sx={{ m: 'auto' }}>
+            <MdxEditor
+                initialMarkdown={initContent}
+                editorRef={ref}
+                handleChange={() => updateProperty('content', ref.current?.getMarkdown())} />
         </Grid>
     )
 };

--- a/src/components/design-panel.tsx
+++ b/src/components/design-panel.tsx
@@ -35,7 +35,6 @@ export const DesignPanel = () => {
     const [untickedForms, setUntickedForms] = useState<string[]>(Object.keys(viewSets).filter((form) => !visibleTypes.includes(form)));
 
     console.log('DesignPanel');
-    console.log('tabIndex is', tabIndex);
     console.log('visible forms ', visibleTypes, '& unticked forms ', untickedForms);
 
     const maxKeys = Object.keys(viewSets).length;

--- a/src/components/info-panel.tsx
+++ b/src/components/info-panel.tsx
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { Alert, Button, Checkbox, FormControlLabel, Grid, TextField, Typography, Card } from "@mui/material";
+import { Alert, Button, Checkbox, FormControlLabel, FormHelperText, Grid, TextField, Typography, Card } from "@mui/material";
 import { useEffect, useState, useRef, Suspense } from "react";
 import { useAppSelector, useAppDispatch } from "../state/hooks";
 import { Notebook, PropertyMap } from "../state/initial";
@@ -120,99 +120,106 @@ export const InfoPanel = () => {
             <Typography variant="h2">General Information</Typography>
             <Card variant="outlined" sx={{ mt: 2 }}>
                 <Grid container spacing={3} p={3}>
-                    <Grid item xs={12} sm={6}>
-                        <TextField
-                            fullWidth
-                            required
-                            label="Project Name"
-                            helperText="Enter a string between 2 and 100 characters long."
-                            name="name"
-                            data-testid="name"
-                            value={metadata.name}
-                            onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
-                                setProp('name', event.target.value);
-                            }}
-                        />
-                    </Grid>
+                    <Grid container item xs={12} spacing={2}>
+                        <Grid item xs={12} sm={4}>
+                            <TextField
+                                fullWidth
+                                required
+                                label="Project Name"
+                                helperText="Enter a string between 2 and 100 characters long."
+                                name="name"
+                                data-testid="name"
+                                value={metadata.name}
+                                onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
+                                    setProp('name', event.target.value);
+                                }}
+                            />
+                        </Grid>
 
-                    <Grid item xs={12} sm={6}>
-                        <TextField
-                            fullWidth
-                            label="Project Lead"
-                            name="project_lead"
-                            value={metadata.project_lead}
-                            onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
-                                setProp('project_lead', event.target.value);
-                            }}
-                        />
-                    </Grid>
+                        <Grid item xs={12} sm={4}>
+                            <TextField
+                                fullWidth
+                                label="Project Lead"
+                                name="project_lead"
+                                value={metadata.project_lead}
+                                onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
+                                    setProp('project_lead', event.target.value);
+                                }}
+                            />
+                        </Grid>
 
-                    <Grid item xs={12}>
-                        <Suspense fallback={<div>Loading...</div>}>
-                            <Card variant="outlined" onBlur={() => setProp('pre_description', ref.current?.getMarkdown() as string)}>
-                                <MDXEditor
-                                    markdown={metadata.pre_description as string}
-                                    plugins={[
-                                        headingsPlugin(),
-                                        listsPlugin(),
-                                        quotePlugin(),
-                                        thematicBreakPlugin(),
-                                        markdownShortcutPlugin(),
-                                        tablePlugin(),
-                                        diffSourcePlugin({ diffMarkdown: metadata.pre_description as string }),
-                                        linkPlugin(),
-                                        toolbarPlugin({
-                                            toolbarContents: () => (
-                                                <DiffSourceToggleWrapper>
-                                                    <UndoRedo />
-                                                    <Separator />
-                                                    <BoldItalicUnderlineToggles />
-                                                    <Separator />
-                                                    <BlockTypeSelect />
-                                                    <Separator />
-                                                    <ListsToggle />
-                                                    <Separator />
-                                                    <InsertTable />
-                                                </DiffSourceToggleWrapper>
-                                            )
-                                        }),
-                                        catchAllPlugin(),
-                                    ]}
-                                    ref={ref}
-                                    contentEditableClassName="mdxEditor"
-                                />
-                            </Card>
-                            {errorMessage && <Alert severity="error">{errorMessage}</Alert>}
-                        </Suspense>
-                    </Grid>
-
-                    <Grid item xs={12} sm={6}>
-                        <TextField
-                            fullWidth
-                            label="Lead Institution"
-                            name="lead_institution"
-                            value={metadata.lead_institution}
-                            onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
-                                setProp('lead_institution', event.target.value);
-                            }}
-                        />
-                    </Grid>
-
-                    <Grid item xs={12} sm={6}>
-                        <FormControlLabel
-                            control={<Checkbox
-                                checked={metadata.showQRCodeButton === "true" ? true : false}
-                                onChange={(e) => setProp('showQRCodeButton', e.target.checked ? "true" : "false")}
-                            />} label="Enable QR Code Search of records" />
-                        <br />
-                        <Typography variant='caption'>Useful if your form includes a QR code field.</Typography>
+                        <Grid item xs={12} sm={4}>
+                            <TextField
+                                fullWidth
+                                label="Lead Institution"
+                                name="lead_institution"
+                                value={metadata.lead_institution}
+                                onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
+                                    setProp('lead_institution', event.target.value);
+                                }}
+                            />
+                        </Grid>
                     </Grid>
 
                     <Grid container item xs={12} spacing={2}>
+                        <Grid item xs={12} sm={8}>
+                            <Suspense fallback={<div>Loading...</div>}>
+                                <Card variant="outlined" onBlur={() => setProp('pre_description', ref.current?.getMarkdown() as string)}>
+                                    <MDXEditor
+                                        placeholder="Start typing a project description..."
+                                        markdown={metadata.pre_description as string}
+                                        plugins={[
+                                            headingsPlugin(),
+                                            listsPlugin(),
+                                            quotePlugin(),
+                                            thematicBreakPlugin(),
+                                            markdownShortcutPlugin(),
+                                            tablePlugin(),
+                                            diffSourcePlugin({ diffMarkdown: metadata.pre_description as string }),
+                                            linkPlugin(),
+                                            toolbarPlugin({
+                                                toolbarContents: () => (
+                                                    <DiffSourceToggleWrapper>
+                                                        <UndoRedo />
+                                                        <Separator />
+                                                        <BoldItalicUnderlineToggles />
+                                                        <Separator />
+                                                        <BlockTypeSelect />
+                                                        <Separator />
+                                                        <ListsToggle />
+                                                        <Separator />
+                                                        <InsertTable />
+                                                    </DiffSourceToggleWrapper>
+                                                )
+                                            }),
+                                            catchAllPlugin(),
+                                        ]}
+                                        ref={ref}
+                                        contentEditableClassName="mdxEditor"
+                                    />
+                                </Card>
+                                {errorMessage && <Alert severity="error">{errorMessage}</Alert>}
+                            </Suspense>
+                            <FormHelperText>
+                                Use the editor above for the project description.
+                                If you use source mode, make sure you put blank lines before and after any markdown syntax for compatibility.
+                            </FormHelperText>
+                        </Grid>
 
+                        <Grid item xs={12} sm={4}>
+                            <FormControlLabel
+                                control={<Checkbox
+                                    checked={metadata.showQRCodeButton === "true" ? true : false}
+                                    onChange={(e) => setProp('showQRCodeButton', e.target.checked ? "true" : "false")}
+                                />} label="Enable QR Code Search of records" />
+                            <FormHelperText>Useful if your form includes a QR code field.</FormHelperText>
+                        </Grid>
+                    </Grid>
+
+                    <Grid container item xs={12} spacing={2}>
                         {Object.keys(extraFields).map((key) => {
                             return (
-                                <Grid item xs={12} key={key}>
+                                <Grid item xs={12} sm={4} key={key}>
                                     <TextField
                                         fullWidth
                                         label={key}
@@ -229,8 +236,11 @@ export const InfoPanel = () => {
                         {alert &&
                             <Grid item xs={12}>
                                 <Alert onClose={() => { setAlert('') }} severity="error">{alert}</Alert>
-                            </Grid>}
+                            </Grid>
+                        }
+                    </Grid>
 
+                    <Grid container item xs={12} spacing={2}>
                         <Grid item xs={5}>
                             <TextField
                                 fullWidth
@@ -253,7 +263,10 @@ export const InfoPanel = () => {
                             <Button
                                 variant="contained"
                                 color="primary"
-                                onClick={addNewMetadataField}>+</Button>
+                                onClick={addNewMetadataField}
+                            >
+                                +
+                            </Button>
                         </Grid>
                     </Grid>
                 </Grid>

--- a/src/components/info-panel.tsx
+++ b/src/components/info-panel.tsx
@@ -84,7 +84,7 @@ export const InfoPanel = () => {
     const addNewMetadataField = () => {
         setAlert('');
         if (metadataFieldName in metadata) {
-            setAlert(`Field '${metadataFieldName}' already exists`);
+            setAlert(`Field '${metadataFieldName}' already exists.`);
         } else {
             setMetadataFieldName('');
             setMetadataFieldValue('');
@@ -119,14 +119,13 @@ export const InfoPanel = () => {
         <div>
             <Typography variant="h2">General Information</Typography>
             <Card variant="outlined" sx={{ mt: 2 }}>
-                <Grid container spacing={3} p={3}>
+                <Grid container spacing={4} p={3}>
                     <Grid container item xs={12} spacing={2}>
                         <Grid item xs={12} sm={4}>
                             <TextField
                                 fullWidth
                                 required
                                 label="Project Name"
-                                helperText="Enter a string between 2 and 100 characters long."
                                 name="name"
                                 data-testid="name"
                                 value={metadata.name}
@@ -134,6 +133,7 @@ export const InfoPanel = () => {
                                     setProp('name', event.target.value);
                                 }}
                             />
+                            <FormHelperText>Enter a string between 2 and 100 characters long.</FormHelperText>
                         </Grid>
 
                         <Grid item xs={12} sm={4}>
@@ -161,112 +161,125 @@ export const InfoPanel = () => {
                         </Grid>
                     </Grid>
 
-                    <Grid container item xs={12} spacing={2}>
-                        <Grid item xs={12} sm={8}>
-                            <Suspense fallback={<div>Loading...</div>}>
-                                <Card variant="outlined" onBlur={() => setProp('pre_description', ref.current?.getMarkdown() as string)}>
-                                    <MDXEditor
-                                        placeholder="Start typing a project description..."
-                                        markdown={metadata.pre_description as string}
-                                        plugins={[
-                                            headingsPlugin(),
-                                            listsPlugin(),
-                                            quotePlugin(),
-                                            thematicBreakPlugin(),
-                                            markdownShortcutPlugin(),
-                                            tablePlugin(),
-                                            diffSourcePlugin({ diffMarkdown: metadata.pre_description as string }),
-                                            linkPlugin(),
-                                            toolbarPlugin({
-                                                toolbarContents: () => (
-                                                    <DiffSourceToggleWrapper>
-                                                        <UndoRedo />
-                                                        <Separator />
-                                                        <BoldItalicUnderlineToggles />
-                                                        <Separator />
-                                                        <BlockTypeSelect />
-                                                        <Separator />
-                                                        <ListsToggle />
-                                                        <Separator />
-                                                        <InsertTable />
-                                                    </DiffSourceToggleWrapper>
-                                                )
-                                            }),
-                                            catchAllPlugin(),
-                                        ]}
-                                        ref={ref}
-                                        contentEditableClassName="mdxEditor"
-                                    />
-                                </Card>
-                                {errorMessage && <Alert severity="error">{errorMessage}</Alert>}
-                            </Suspense>
-                            <FormHelperText>
-                                Use the editor above for the project description.
-                                If you use source mode, make sure you put blank lines before and after any markdown syntax for compatibility.
-                            </FormHelperText>
-                        </Grid>
+                    <Grid item xs={12}>
+                        <Suspense fallback={<div>Loading...</div>}>
+                            {errorMessage && <Alert severity="error">{errorMessage}</Alert>}
+                            <Card variant="outlined">
+                                <MDXEditor
+                                    placeholder="Start typing a project description..."
+                                    markdown={metadata.pre_description as string}
+                                    plugins={[
+                                        headingsPlugin(),
+                                        listsPlugin(),
+                                        quotePlugin(),
+                                        thematicBreakPlugin(),
+                                        markdownShortcutPlugin(),
+                                        tablePlugin(),
+                                        diffSourcePlugin({ diffMarkdown: metadata.pre_description as string }),
+                                        linkPlugin(),
+                                        toolbarPlugin({
+                                            toolbarContents: () => (
+                                                <DiffSourceToggleWrapper>
+                                                    <UndoRedo />
+                                                    <Separator />
+                                                    <BoldItalicUnderlineToggles />
+                                                    <Separator />
+                                                    <BlockTypeSelect />
+                                                    <Separator />
+                                                    <ListsToggle />
+                                                    <Separator />
+                                                    <InsertTable />
+                                                </DiffSourceToggleWrapper>
+                                            )
+                                        }),
+                                        catchAllPlugin(),
+                                    ]}
+                                    ref={ref}
+                                    contentEditableClassName="mdxEditor"
+                                    onChange={() => setProp('pre_description', ref.current?.getMarkdown() as string)}
+                                />
+                            </Card>
+                        </Suspense>
+                        <FormHelperText>
+                            Use the editor above for the project description.
+                            If you use source mode, make sure you put blank lines before and after any markdown syntax for compatibility.
+                        </FormHelperText>
+                    </Grid>
 
+                    <Grid container item xs={12} spacing={2} justifyContent="space-between">
                         <Grid item xs={12} sm={4}>
                             <FormControlLabel
                                 control={<Checkbox
-                                    checked={metadata.showQRCodeButton === "true" ? true : false}
+                                    checked={metadata.showQRCodeButton === "true"}
                                     onChange={(e) => setProp('showQRCodeButton', e.target.checked ? "true" : "false")}
                                 />} label="Enable QR Code Search of records" />
                             <FormHelperText>Useful if your form includes a QR code field.</FormHelperText>
                         </Grid>
-                    </Grid>
 
-                    <Grid container item xs={12} spacing={2}>
-                        {Object.keys(extraFields).map((key) => {
-                            return (
-                                <Grid item xs={12} sm={4} key={key}>
-                                    <TextField
-                                        fullWidth
-                                        label={key}
-                                        name={key}
-                                        value={extraFields[key]}
-                                        onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
-                                            setProp(key, event.target.value);
-                                        }}
-                                    />
+                        <Grid item xs={12} sm={8}>
+                            <Card variant="outlined">
+                                <Grid container p={2.5} spacing={3}>
+                                    <Grid
+                                        container item xs={12} sm={5}
+                                        direction="column"
+                                        justifyContent="flex-start"
+                                        alignItems="flex-start"
+                                    >
+                                        <form onSubmit={(e: React.FormEvent<HTMLFormElement>) => {
+                                            e.preventDefault();
+                                            addNewMetadataField();
+                                        }}>
+                                            <TextField
+                                                fullWidth
+                                                label="Metadata Field Name"
+                                                name="metadata_field_name"
+                                                size="small"
+                                                value={metadataFieldName}
+                                                onChange={updateMetadataFieldName}
+                                            />
+                                            <TextField
+                                                fullWidth
+                                                sx={{ mt: 1.5 }}
+                                                label="Metadata Field Value"
+                                                name="metadata_field_value"
+                                                size="small"
+                                                value={metadataFieldValue}
+                                                onChange={updateMetadataFieldValue}
+                                            />
+                                            <Button
+                                                sx={{ my: 2.5 }}
+                                                variant="contained"
+                                                color="primary"
+                                                type="submit"
+                                            >
+                                                Create New Field
+                                            </Button>
+                                            {alert &&
+                                                <Alert onClose={() => { setAlert('') }} severity="error">{alert}</Alert>
+                                            }
+                                        </form>
+                                    </Grid>
+
+                                    <Grid container item xs={12} sm={7} rowGap={1}>
+                                        {Object.keys(extraFields).map((key) => {
+                                            return (
+                                                <Grid item xs={12} key={key}>
+                                                    <TextField
+                                                        fullWidth
+                                                        label={key}
+                                                        name={key}
+                                                        value={extraFields[key]}
+                                                        onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
+                                                            setProp(key, event.target.value);
+                                                        }}
+                                                    />
+                                                </Grid>
+                                            );
+                                        })}
+                                    </Grid>
                                 </Grid>
-                            );
-                        })}
-
-                        {alert &&
-                            <Grid item xs={12}>
-                                <Alert onClose={() => { setAlert('') }} severity="error">{alert}</Alert>
-                            </Grid>
-                        }
-                    </Grid>
-
-                    <Grid container item xs={12} spacing={2}>
-                        <Grid item xs={5}>
-                            <TextField
-                                fullWidth
-                                label="Metadata Field Name"
-                                name="metadata_field_name"
-                                value={metadataFieldName}
-                                onChange={updateMetadataFieldName}
-                            />
-                        </Grid>
-                        <Grid item xs={5}>
-                            <TextField
-                                fullWidth
-                                label="Metadata Field Value"
-                                name="metadata_field_value"
-                                value={metadataFieldValue}
-                                onChange={updateMetadataFieldValue}
-                            />
-                        </Grid>
-                        <Grid item xs={2}>
-                            <Button
-                                variant="contained"
-                                color="primary"
-                                onClick={addNewMetadataField}
-                            >
-                                +
-                            </Button>
+                            </Card>
+                            <FormHelperText>Use the form above to create new metadata fields, if needed.</FormHelperText>
                         </Grid>
                     </Grid>
                 </Grid>

--- a/src/components/info-panel.tsx
+++ b/src/components/info-panel.tsx
@@ -124,54 +124,40 @@ export const InfoPanel = () => {
                     </Grid>
 
                     <Grid item xs={12}>
-                        {showMDXEditor ? (
-                            <Card variant="outlined">
-                                {/* <Alert severity="info">Use the editor below for the project description.</Alert> */}
-                                <Suspense fallback={<div>Loading...</div>}>
-                                    <MDXEditor
-                                        markdown={metadata.pre_description as string}
-                                        plugins={[
-                                            headingsPlugin(),
-                                            listsPlugin(),
-                                            quotePlugin(),
-                                            thematicBreakPlugin(),
-                                            markdownShortcutPlugin(),
-                                            tablePlugin(),
-                                            diffSourcePlugin({ diffMarkdown: metadata.pre_description as string }),
-                                            toolbarPlugin({
-                                                toolbarContents: () => (
-                                                    <DiffSourceToggleWrapper>
-                                                        <UndoRedo />
-                                                        <Separator />
-                                                        <BoldItalicUnderlineToggles />
-                                                        <Separator />
-                                                        <BlockTypeSelect />
-                                                        <Separator />
-                                                        <ListsToggle />
-                                                        <Separator />
-                                                        <InsertTable />
-                                                    </DiffSourceToggleWrapper>
-                                                )
-                                            }),
-                                        ]}
-                                        ref={ref}
-                                        //onChange={() => setProp('pre_description', ref.current?.getMarkdown() as string)}
-                                        contentEditableClassName="mdxEditor"
-                                    />
-                                    <Button onClick={() => {
-                                        setProp('pre_description', ref.current?.getMarkdown() as string)
-                                        setShowMDXEditor(false)
-                                    }}>
-                                        Done?
-                                    </Button>
-                                </Suspense>
+                        <Suspense fallback={<div>Loading...</div>}>
+                            <Card variant="outlined" onBlur={() => setProp('pre_description', ref.current?.getMarkdown() as string)}>
+                                <MDXEditor
+                                    markdown={metadata.pre_description as string}
+                                    plugins={[
+                                        headingsPlugin(),
+                                        listsPlugin(),
+                                        quotePlugin(),
+                                        thematicBreakPlugin(),
+                                        markdownShortcutPlugin(),
+                                        tablePlugin(),
+                                        diffSourcePlugin({ diffMarkdown: metadata.pre_description as string }),
+                                        toolbarPlugin({
+                                            toolbarContents: () => (
+                                                <DiffSourceToggleWrapper>
+                                                    <UndoRedo />
+                                                    <Separator />
+                                                    <BoldItalicUnderlineToggles />
+                                                    <Separator />
+                                                    <BlockTypeSelect />
+                                                    <Separator />
+                                                    <ListsToggle />
+                                                    <Separator />
+                                                    <InsertTable />
+                                                </DiffSourceToggleWrapper>
+                                            )
+                                        }),
+                                    ]}
+                                    ref={ref}
+                                    //onChange={() => setProp('pre_description', ref.current?.getMarkdown() as string)}
+                                    contentEditableClassName="mdxEditor"
+                                />
                             </Card>
-                        ) : (
-                            <Card variant="outlined">
-                                <Button onClick={() => setShowMDXEditor(true)}>Click to edit the project description</Button>
-                            </Card>
-                        )
-                        }
+                        </Suspense>
                     </Grid>
 
                     <Grid item xs={12} sm={6}>

--- a/src/components/info-panel.tsx
+++ b/src/components/info-panel.tsx
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { Alert, Button, Checkbox, FormControlLabel, Grid, TextField, Typography } from "@mui/material";
+import { Alert, Button, Checkbox, FormControlLabel, Grid, TextField, Typography, Card } from "@mui/material";
 import { useEffect, useState, useRef, Suspense } from "react";
 import { useAppSelector, useAppDispatch } from "../state/hooks";
 
@@ -28,6 +28,7 @@ import { quotePlugin } from '@mdxeditor/editor/plugins/quote';
 import { thematicBreakPlugin } from '@mdxeditor/editor/plugins/thematic-break';
 import { markdownShortcutPlugin } from '@mdxeditor/editor/plugins/markdown-shortcut';
 import { tablePlugin } from '@mdxeditor/editor/plugins/table';
+import { diffSourcePlugin } from '@mdxeditor/editor/plugins/diff-source';
 
 // importing the desired toolbar toggle components
 import { UndoRedo } from '@mdxeditor/editor/plugins/toolbar/components/UndoRedo';
@@ -35,6 +36,7 @@ import { BoldItalicUnderlineToggles } from '@mdxeditor/editor/plugins/toolbar/co
 import { BlockTypeSelect } from '@mdxeditor/editor/plugins/toolbar/components/BlockTypeSelect';
 import { ListsToggle } from '@mdxeditor/editor/plugins/toolbar/components/ListsToggle';
 import { InsertTable } from '@mdxeditor/editor/plugins/toolbar/components/InsertTable';
+import { DiffSourceToggleWrapper } from '@mdxeditor/editor/plugins/toolbar/components/DiffSourceToggleWrapper';
 
 import { Notebook, PropertyMap } from "../state/initial";
 
@@ -43,14 +45,16 @@ export const InfoPanel = () => {
     const metadata = useAppSelector((state: Notebook) => state.metadata);
     const dispatch = useAppDispatch();
 
-    const ref = useRef<MDXEditorMethods>(null)
+    const ref = useRef<MDXEditorMethods>(null);
 
     const [metadataFieldName, setMetadataFieldName] = useState('');
     const [metadataFieldValue, setMetadataFieldValue] = useState('');
     const [extraFields, setExtraFields] = useState<PropertyMap>({});
     const [alert, setAlert] = useState('');
+    const [showMDXEditor, setShowMDXEditor] = useState(false);
 
     useEffect(() => {
+        console.log('here')
         const knownFields = ['name', 'pre_description', 'behaviours', 'meta',
             'project_lead', 'lead_institution', 'showQRCodeButton',
             'access', 'accesses', 'forms', 'filenames',
@@ -64,7 +68,7 @@ export const InfoPanel = () => {
         setExtraFields(newExtraFields);
     }, [metadata]);
 
-    const setProp = (property: string, value: string | undefined) => {
+    const setProp = (property: string, value: string) => {
         dispatch({ type: 'metadata/propertyUpdated', payload: { property, value } });
     };
 
@@ -90,140 +94,158 @@ export const InfoPanel = () => {
     return (
         <div>
             <Typography variant="h2">General Information</Typography>
-
-            <Grid container spacing={2} pt={3}>
-                <Grid item xs={12} sm={6}>
-                    <TextField
-                        fullWidth
-                        required
-                        label="Project Name"
-                        helperText="Enter a string between 2 and 100 characters long."
-                        name="name"
-                        data-testid="name"
-                        value={metadata.name}
-                        onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
-                            setProp('name', event.target.value);
-                        }}
-                    />
-                </Grid>
-                <Grid item xs={12} sm={6}>
-                    <TextField
-                        fullWidth
-                        label="Project Lead"
-                        name="project_lead"
-                        value={metadata.project_lead}
-                        onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
-                            setProp('project_lead', event.target.value);
-                        }}
-                    />
-                </Grid>
-                <Grid item xs={12}>
-                    <Alert severity="info">Use the editor below for the project description.</Alert>
-                    <Suspense fallback={<div>Loading...</div>}>
-                        <MDXEditor
-                            markdown={metadata.pre_description as string}
-                            plugins={[
-                                headingsPlugin(),
-                                listsPlugin(),
-                                quotePlugin(),
-                                thematicBreakPlugin(),
-                                markdownShortcutPlugin(),
-                                tablePlugin(),
-                                toolbarPlugin({
-                                    toolbarContents: () => (
-                                        <>
-                                            <UndoRedo />
-                                            <Separator />
-                                            <BoldItalicUnderlineToggles />
-                                            <Separator />
-                                            <BlockTypeSelect />
-                                            <Separator />
-                                            <ListsToggle />
-                                            <Separator />
-                                            <InsertTable />
-                                        </>
-                                    )
-                                }),
-
-                            ]}
-                            ref={ref}
-                            onChange={() => setProp('pre_description', ref.current?.getMarkdown())}
-                            contentEditableClassName="mdxEditor"
-                        />
-                    </Suspense>
-                </Grid>
-                <Grid item xs={12} sm={6}>
-                    <TextField
-                        fullWidth
-                        label="Lead Institution"
-                        name="lead_institution"
-                        value={metadata.lead_institution}
-                        onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
-                            setProp('lead_institution', event.target.value);
-                        }}
-                    />
-                </Grid>
-                <Grid item xs={12} sm={6}>
-                    <FormControlLabel
-                        control={<Checkbox
-                            checked={metadata.showQRCodeButton === "true" ? true : false}
-                            onChange={(e) => setProp('showQRCodeButton', e.target.checked ? "true" : "false")}
-                        />} label="Enable QR Code Search of records" />
-                    <br />
-                    <Typography variant='caption'>Useful if your form includes a QR code field.</Typography>
-                </Grid>
-
-                <Grid container item xs={12} spacing={2}>
-
-                    {Object.keys(extraFields).map((key) => {
-                        return (
-                            <Grid item xs={12} key={key}>
-                                <TextField
-                                    fullWidth
-                                    label={key}
-                                    name={key}
-                                    value={extraFields[key]}
-                                    onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
-                                        setProp(key, event.target.value);
-                                    }}
-                                />
-                            </Grid>
-                        );
-                    })}
-
-                    {alert &&
-                        <Grid item xs={12}>
-                            <Alert onClose={() => { setAlert('') }} severity="error">{alert}</Alert>
-                        </Grid>}
-
-                    <Grid item xs={5}>
+            <Card variant="outlined" sx={{ mt: 2 }}>
+                <Grid container spacing={3} p={3}>
+                    <Grid item xs={12} sm={6}>
                         <TextField
                             fullWidth
-                            label="Metadata Field Name"
-                            name="metadata_field_name"
-                            value={metadataFieldName}
-                            onChange={updateMetadataFieldName}
+                            required
+                            label="Project Name"
+                            helperText="Enter a string between 2 and 100 characters long."
+                            name="name"
+                            data-testid="name"
+                            value={metadata.name}
+                            onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
+                                setProp('name', event.target.value);
+                            }}
                         />
                     </Grid>
-                    <Grid item xs={5}>
+
+                    <Grid item xs={12} sm={6}>
                         <TextField
                             fullWidth
-                            label="Metadata Field Value"
-                            name="metadata_field_value"
-                            value={metadataFieldValue}
-                            onChange={updateMetadataFieldValue}
+                            label="Project Lead"
+                            name="project_lead"
+                            value={metadata.project_lead}
+                            onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
+                                setProp('project_lead', event.target.value);
+                            }}
                         />
                     </Grid>
-                    <Grid item xs={2}>
-                        <Button
-                            variant="contained"
-                            color="primary"
-                            onClick={addNewMetadataField}>+</Button>
+
+                    <Grid item xs={12}>
+                        {showMDXEditor ? (
+                            <Card variant="outlined">
+                                {/* <Alert severity="info">Use the editor below for the project description.</Alert> */}
+                                <Suspense fallback={<div>Loading...</div>}>
+                                    <MDXEditor
+                                        markdown={metadata.pre_description as string}
+                                        plugins={[
+                                            headingsPlugin(),
+                                            listsPlugin(),
+                                            quotePlugin(),
+                                            thematicBreakPlugin(),
+                                            markdownShortcutPlugin(),
+                                            tablePlugin(),
+                                            diffSourcePlugin({ diffMarkdown: metadata.pre_description as string }),
+                                            toolbarPlugin({
+                                                toolbarContents: () => (
+                                                    <DiffSourceToggleWrapper>
+                                                        <UndoRedo />
+                                                        <Separator />
+                                                        <BoldItalicUnderlineToggles />
+                                                        <Separator />
+                                                        <BlockTypeSelect />
+                                                        <Separator />
+                                                        <ListsToggle />
+                                                        <Separator />
+                                                        <InsertTable />
+                                                    </DiffSourceToggleWrapper>
+                                                )
+                                            }),
+                                        ]}
+                                        ref={ref}
+                                        //onChange={() => setProp('pre_description', ref.current?.getMarkdown() as string)}
+                                        contentEditableClassName="mdxEditor"
+                                    />
+                                    <Button onClick={() => {
+                                        setProp('pre_description', ref.current?.getMarkdown() as string)
+                                        setShowMDXEditor(false)
+                                    }}>
+                                        Done?
+                                    </Button>
+                                </Suspense>
+                            </Card>
+                        ) : (
+                            <Card variant="outlined">
+                                <Button onClick={() => setShowMDXEditor(true)}>Click to edit the project description</Button>
+                            </Card>
+                        )
+                        }
+                    </Grid>
+
+                    <Grid item xs={12} sm={6}>
+                        <TextField
+                            fullWidth
+                            label="Lead Institution"
+                            name="lead_institution"
+                            value={metadata.lead_institution}
+                            onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
+                                setProp('lead_institution', event.target.value);
+                            }}
+                        />
+                    </Grid>
+
+                    <Grid item xs={12} sm={6}>
+                        <FormControlLabel
+                            control={<Checkbox
+                                checked={metadata.showQRCodeButton === "true" ? true : false}
+                                onChange={(e) => setProp('showQRCodeButton', e.target.checked ? "true" : "false")}
+                            />} label="Enable QR Code Search of records" />
+                        <br />
+                        <Typography variant='caption'>Useful if your form includes a QR code field.</Typography>
+                    </Grid>
+
+                    <Grid container item xs={12} spacing={2}>
+
+                        {Object.keys(extraFields).map((key) => {
+                            return (
+                                <Grid item xs={12} key={key}>
+                                    <TextField
+                                        fullWidth
+                                        label={key}
+                                        name={key}
+                                        value={extraFields[key]}
+                                        onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
+                                            setProp(key, event.target.value);
+                                        }}
+                                    />
+                                </Grid>
+                            );
+                        })}
+
+                        {alert &&
+                            <Grid item xs={12}>
+                                <Alert onClose={() => { setAlert('') }} severity="error">{alert}</Alert>
+                            </Grid>}
+
+                        <Grid item xs={5}>
+                            <TextField
+                                fullWidth
+                                label="Metadata Field Name"
+                                name="metadata_field_name"
+                                value={metadataFieldName}
+                                onChange={updateMetadataFieldName}
+                            />
+                        </Grid>
+                        <Grid item xs={5}>
+                            <TextField
+                                fullWidth
+                                label="Metadata Field Value"
+                                name="metadata_field_value"
+                                value={metadataFieldValue}
+                                onChange={updateMetadataFieldValue}
+                            />
+                        </Grid>
+                        <Grid item xs={2}>
+                            <Button
+                                variant="contained"
+                                color="primary"
+                                onClick={addNewMetadataField}>+</Button>
+                        </Grid>
                     </Grid>
                 </Grid>
-
-            </Grid>
-
+            </Card>
         </div>
     );
 }

--- a/src/components/info-panel.tsx
+++ b/src/components/info-panel.tsx
@@ -247,7 +247,7 @@ export const InfoPanel = () => {
                                                 onChange={updateMetadataFieldValue}
                                             />
                                             <Button
-                                                sx={{ my: 2.5 }}
+                                                sx={{ mt: 2.5 }}
                                                 variant="contained"
                                                 color="primary"
                                                 type="submit"
@@ -255,7 +255,7 @@ export const InfoPanel = () => {
                                                 Create New Field
                                             </Button>
                                             {alert &&
-                                                <Alert onClose={() => { setAlert('') }} severity="error">{alert}</Alert>
+                                                <Alert onClose={() => { setAlert('') }} severity="error" sx={{ mt: 2.5 }}>{alert}</Alert>
                                             }
                                         </form>
                                     </Grid>

--- a/src/components/info-panel.tsx
+++ b/src/components/info-panel.tsx
@@ -59,7 +59,7 @@ export const InfoPanel = () => {
             'project_lead', 'lead_institution', 'showQRCodeButton',
             'access', 'accesses', 'forms', 'filenames',
             'ispublic', 'isrequest', 'sections',
-            'project_status', 'schema_version'];
+            'project_status', 'schema_version', 'notebook_version'];
         const unknownFields = Object.keys(metadata).filter((key) => !knownFields.includes(key));
         const newExtraFields: PropertyMap = {};
         unknownFields.forEach((key) => {
@@ -119,8 +119,8 @@ export const InfoPanel = () => {
         <div>
             <Typography variant="h2">General Information</Typography>
             <Card variant="outlined" sx={{ mt: 2 }}>
-                <Grid container spacing={4} p={3}>
-                    <Grid container item xs={12} spacing={2}>
+                <Grid container spacing={5} p={3}>
+                    <Grid container item xs={12} spacing={2.5}>
                         <Grid item xs={12} sm={4}>
                             <TextField
                                 fullWidth
@@ -206,14 +206,30 @@ export const InfoPanel = () => {
                         </FormHelperText>
                     </Grid>
 
-                    <Grid container item xs={12} spacing={2} justifyContent="space-between">
-                        <Grid item xs={12} sm={4}>
-                            <FormControlLabel
-                                control={<Checkbox
-                                    checked={metadata.showQRCodeButton === "true"}
-                                    onChange={(e) => setProp('showQRCodeButton', e.target.checked ? "true" : "false")}
-                                />} label="Enable QR Code Search of records" />
-                            <FormHelperText>Useful if your form includes a QR code field.</FormHelperText>
+                    <Grid container item xs={12} spacing={2.5} justifyContent="space-between">
+                        <Grid container item xs={12} sm={4} spacing={5}>
+                            <Grid item xs={12}>
+                                <FormControlLabel
+                                    control={<Checkbox
+                                        checked={metadata.showQRCodeButton === "true"}
+                                        onChange={(e) => setProp('showQRCodeButton', e.target.checked ? "true" : "false")}
+                                    />} label="Enable QR Code Search of Records" />
+                                <FormHelperText>Useful if your form includes a QR code field.</FormHelperText>
+                            </Grid>
+                            <Grid item xs={12}>
+                                <Grid item xs={12} sm={10}>
+                                    <TextField
+                                        fullWidth
+                                        label="Notebook Version"
+                                        name="notebook_version"
+                                        value={metadata.notebook_version}
+                                        onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
+                                            setProp('notebook_version', event.target.value);
+                                        }}
+                                    />
+                                    <FormHelperText>Use this field to differentiate between versions of this notebook; e.g. 1.0, 1.1 and so on.</FormHelperText>
+                                </Grid>
+                            </Grid>
                         </Grid>
 
                         <Grid item xs={12} sm={8}>

--- a/src/components/mdx-editor.tsx
+++ b/src/components/mdx-editor.tsx
@@ -1,0 +1,122 @@
+// Copyright 2023 FAIMS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { Suspense, useState } from "react";
+
+import { Grid, FormHelperText, Alert, Card } from "@mui/material";
+import '@mdxeditor/editor/style.css';
+
+// importing the editor and the plugin from their full paths
+import { MDXEditor } from '@mdxeditor/editor/MDXEditor';
+import { MDXEditorMethods, MdastImportVisitor, Separator, realmPlugin, system } from '@mdxeditor/editor';
+import { toolbarPlugin } from '@mdxeditor/editor/plugins/toolbar';
+import { headingsPlugin } from '@mdxeditor/editor/plugins/headings';
+import { listsPlugin } from '@mdxeditor/editor/plugins/lists';
+import { quotePlugin } from '@mdxeditor/editor/plugins/quote';
+import { thematicBreakPlugin } from '@mdxeditor/editor/plugins/thematic-break';
+import { markdownShortcutPlugin } from '@mdxeditor/editor/plugins/markdown-shortcut';
+import { tablePlugin } from '@mdxeditor/editor/plugins/table';
+import { diffSourcePlugin } from '@mdxeditor/editor/plugins/diff-source';
+import { linkPlugin } from '@mdxeditor/editor/plugins/link';
+
+// importing the desired toolbar toggle components
+import { UndoRedo } from '@mdxeditor/editor/plugins/toolbar/components/UndoRedo';
+import { BoldItalicUnderlineToggles } from '@mdxeditor/editor/plugins/toolbar/components/BoldItalicUnderlineToggles';
+import { BlockTypeSelect } from '@mdxeditor/editor/plugins/toolbar/components/BlockTypeSelect';
+import { ListsToggle } from '@mdxeditor/editor/plugins/toolbar/components/ListsToggle';
+import { InsertTable } from '@mdxeditor/editor/plugins/toolbar/components/InsertTable';
+import { DiffSourceToggleWrapper } from '@mdxeditor/editor/plugins/toolbar/components/DiffSourceToggleWrapper';
+
+
+type Props = {
+    initialMarkdown: string,
+    editorRef: React.Ref<MDXEditorMethods> | undefined,
+    handleChange: ((markdown: string) => void) | undefined,
+};
+
+export const MdxEditor = ({ initialMarkdown, editorRef, handleChange }: Props) => {
+
+    const [errorMessage, setErrorMessage] = useState('');
+
+    /*
+       The following catchAll code is taken from and inspired by: 
+       https://github.com/mdx-editor/editor/issues/202#issuecomment-1827182167 & 
+       https://github.com/mdx-editor/editor/issues/95#issuecomment-1755320066 
+    */
+    const catchAllVisitor: MdastImportVisitor<any> = {
+        testNode: () => true,
+        visitNode: ({ mdastNode, actions }) => {
+            // deviating from the example shown in the second link,
+            // for now, I'm simply showing an error message
+            setErrorMessage(`Sorry, we currently do not support the markdown ${mdastNode?.type} option. 
+                    What you have just written was automatically removed. Please continue carefully.`);
+        }
+    };
+
+    const [catchAllPlugin] = realmPlugin({
+        id: "catchAll",
+        systemSpec: system(() => ({})),
+        init: (realm) => {
+            realm.pubKey("addImportVisitor", catchAllVisitor);
+        }
+    });
+
+    return (
+        <Grid item xs={12}>
+            <Suspense fallback={<div>Loading...</div>}>
+                {errorMessage &&
+                    <Alert onClose={() => { setErrorMessage('') }} severity="error">
+                        {errorMessage}
+                    </Alert>
+                }
+                <Card variant="outlined">
+                    <MDXEditor
+                        placeholder="Start typing..."
+                        markdown={initialMarkdown}
+                        plugins={[
+                            headingsPlugin(),
+                            listsPlugin(),
+                            quotePlugin(),
+                            thematicBreakPlugin(),
+                            markdownShortcutPlugin(),
+                            tablePlugin(),
+                            diffSourcePlugin({ diffMarkdown: initialMarkdown }),
+                            linkPlugin(),
+                            toolbarPlugin({
+                                toolbarContents: () => (
+                                    <DiffSourceToggleWrapper>
+                                        <UndoRedo />
+                                        <Separator />
+                                        <BoldItalicUnderlineToggles />
+                                        <Separator />
+                                        <BlockTypeSelect />
+                                        <Separator />
+                                        <ListsToggle />
+                                        <Separator />
+                                        <InsertTable />
+                                    </DiffSourceToggleWrapper>
+                                )
+                            }),
+                            catchAllPlugin(),
+                        ]}
+                        ref={editorRef}
+                        onChange={handleChange}
+                        contentEditableClassName="mdxEditor"
+                    />
+                </Card>
+            </Suspense>
+            <FormHelperText>Use this editor to add rich text to your notebook.</FormHelperText>
+        </Grid>
+    )
+}

--- a/src/components/notebook-editor.tsx
+++ b/src/components/notebook-editor.tsx
@@ -82,7 +82,7 @@ export const NotebookEditor = () => {
                         </Box>
                         
                         <TabPanel value="0"><NotebookLoader loadFn={loadNotebook} afterLoad={goToFirstTab} /></TabPanel>
-                        <TabPanel value="1"><InfoPanel /></TabPanel>
+                        <TabPanel value="1" sx={{ paddingX: 0 }}><InfoPanel /></TabPanel>
                         <TabPanel value="3"><DesignPanel /></TabPanel>
                         <TabPanel value="4"><ReviewPanel /></TabPanel>
 


### PR DESCRIPTION
# Issue #28
This PR extends the MDXEditor to allow a user to directly edit the markdown source, among other things.

## Summary

- Created reusable MdxEditor component
- Extended editor to include the diffSourcePlugin, which offers 3 modes: rich-text, diff and source
- Extended editor to include a catchAllPlugin, which offers the ability to show error messages to the user, and prevents the app from crashing 
- Improved the UI for the Info panel