### PR TITLE
Fix crash bug in forms

### DIFF
--- a/src/components/Fields/RichTextEditor.tsx
+++ b/src/components/Fields/RichTextEditor.tsx
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { Grid } from "@mui/material";
+import { Grid, FormHelperText } from "@mui/material";
 import { useAppSelector, useAppDispatch } from "../../state/hooks";
 import { useRef } from "react";
 import { MDXEditorMethods } from '@mdxeditor/editor';
@@ -54,10 +54,14 @@ export const RichTextEditor = ({ fieldName }: { fieldName: string }) => {
 
     return (
         <Grid container item xs={12} sm={8} sx={{ m: 'auto' }}>
-            <MdxEditor
-                initialMarkdown={initContent}
-                editorRef={ref}
-                handleChange={() => updateProperty('content', ref.current?.getMarkdown())} />
+            <Grid item xs={12}>
+                <MdxEditor
+                    initialMarkdown={initContent}
+                    editorRef={ref}
+                    handleChange={() => updateProperty('content', ref.current?.getMarkdown())} 
+                />
+                <FormHelperText>Use this editor to add rich text to your notebook.</FormHelperText>
+            </Grid>
         </Grid>
     )
 };

--- a/src/components/design-panel.tsx
+++ b/src/components/design-panel.tsx
@@ -58,6 +58,37 @@ export const DesignPanel = () => {
         }
     }
 
+    const handleDeleteFormTabChange = (viewSetID: string) => {
+        if (untickedForms.includes(viewSetID)) {
+            // if the form we want to delete is unticked, remove it from the local state
+            // this is a special case as the array that holds these forms in the frontend
+            // has nothing to do with the state in the redux store 
+            setUntickedForms(untickedForms.filter((untickedForm) => untickedForm !== viewSetID));
+
+            if (untickedForms.indexOf(viewSetID) === untickedForms.length - 1 && untickedForms.length > 1) {
+                // ensure an intuitive tab index jump when an unticked form at the end of the array gets deleted
+                // that is, jump to the second to last unticked form
+                // not to the "+" tab
+                // this is scenario 2, see PR
+                setTabIndex(`${visibleTypes.length + untickedForms.length - 2}`);
+            }
+        }
+
+        if (visibleTypes.includes(viewSetID)) {
+            // handle intuitive tab index jumps
+
+            // scenario 1
+            if (visibleTypes.indexOf(viewSetID) === visibleTypes.length - 1 && visibleTypes.length > 1) {
+                setTabIndex(`${visibleTypes.length - 2}`);
+            }
+
+            // scenario 3
+            if (visibleTypes.length === 1) {
+                setTabIndex(`${maxKeys - 1}`);
+            }
+        }
+    }
+
     const addNewForm = () => {
         setAlertMessage('');
         try {
@@ -181,7 +212,13 @@ export const DesignPanel = () => {
             {visibleTypes.map((form: string, index: number) => {
                 return (
                     <TabPanel key={index} value={`${index}`} sx={{ paddingX: 0 }}>
-                        <FormEditor viewSetId={form} moveCallback={moveForm} moveButtonsDisabled={false} handleChangeCallback={handleCheckboxTabChange} />
+                        <FormEditor
+                            viewSetId={form}
+                            moveCallback={moveForm}
+                            moveButtonsDisabled={false}
+                            handleChangeCallback={handleCheckboxTabChange}
+                            handleDeleteCallback={handleDeleteFormTabChange}
+                        />
                     </TabPanel>
                 )
             })}
@@ -189,7 +226,13 @@ export const DesignPanel = () => {
                 const startIndex: number = index + visibleTypes.length;
                 return (
                     <TabPanel key={startIndex} value={`${startIndex}`} sx={{ paddingX: 0 }}>
-                        <FormEditor viewSetId={form} moveCallback={moveForm} moveButtonsDisabled={true} handleChangeCallback={handleCheckboxTabChange} />
+                        <FormEditor
+                            viewSetId={form}
+                            moveCallback={moveForm}
+                            moveButtonsDisabled={true}
+                            handleChangeCallback={handleCheckboxTabChange}
+                            handleDeleteCallback={handleDeleteFormTabChange}
+                        />
                     </TabPanel>
                 )
             })}

--- a/src/components/form-editor.tsx
+++ b/src/components/form-editor.tsx
@@ -36,9 +36,10 @@ type Props = {
     moveCallback: (viewSetID: string, moveDirection: 'left' | 'right') => void,
     moveButtonsDisabled: boolean,
     handleChangeCallback: (viewSetID: string, ticked: boolean) => void,
+    handleDeleteCallback: (viewSetID: string) => void,
 }
 
-export const FormEditor = ({ viewSetId, moveCallback, moveButtonsDisabled, handleChangeCallback }: Props) => {
+export const FormEditor = ({ viewSetId, moveCallback, moveButtonsDisabled, handleChangeCallback, handleDeleteCallback }: Props) => {
 
     const visibleTypes = useAppSelector((state: Notebook) => state['ui-specification'].visible_types);
     const viewsets = useAppSelector((state: Notebook) => state['ui-specification'].viewsets);
@@ -203,6 +204,7 @@ export const FormEditor = ({ viewSetId, moveCallback, moveButtonsDisabled, handl
             setPreventDeleteDialog(true);
         }
         else {
+            handleDeleteCallback(viewSetId);
             dispatch({ type: 'ui-specification/viewSetDeleted', payload: { viewSetId: viewSetId } });
             handleClose();
         }

--- a/src/components/info-panel.tsx
+++ b/src/components/info-panel.tsx
@@ -116,11 +116,17 @@ export const InfoPanel = () => {
                         </Grid>
                     </Grid>
 
-                    <MdxEditor
-                        initialMarkdown={metadata.pre_description as string}
-                        editorRef={ref}
-                        handleChange={() => setProp('pre_description', ref.current?.getMarkdown() as string)}
-                    />
+                    <Grid item xs={12}>
+                        <MdxEditor
+                            initialMarkdown={metadata.pre_description as string}
+                            editorRef={ref}
+                            handleChange={() => setProp('pre_description', ref.current?.getMarkdown() as string)}
+                        />
+                        <FormHelperText>
+                            Use the editor above for the project description.
+                            If you use source mode, make sure you put blank lines before and after any markdown syntax for compatibility.
+                        </FormHelperText>
+                    </Grid>
 
                     <Grid container item xs={12} spacing={2.5} justifyContent="space-between">
                         <Grid container item xs={12} sm={4} spacing={5}>

--- a/src/components/mdx-editor.tsx
+++ b/src/components/mdx-editor.tsx
@@ -14,7 +14,7 @@
 
 import { Suspense, useState } from "react";
 
-import { Grid, FormHelperText, Alert, Card } from "@mui/material";
+import { Alert, Card } from "@mui/material";
 import '@mdxeditor/editor/style.css';
 
 // importing the editor and the plugin from their full paths
@@ -73,50 +73,47 @@ export const MdxEditor = ({ initialMarkdown, editorRef, handleChange }: Props) =
     });
 
     return (
-        <Grid item xs={12}>
-            <Suspense fallback={<div>Loading...</div>}>
-                {errorMessage &&
-                    <Alert onClose={() => { setErrorMessage('') }} severity="error">
-                        {errorMessage}
-                    </Alert>
-                }
-                <Card variant="outlined">
-                    <MDXEditor
-                        placeholder="Start typing..."
-                        markdown={initialMarkdown}
-                        plugins={[
-                            headingsPlugin(),
-                            listsPlugin(),
-                            quotePlugin(),
-                            thematicBreakPlugin(),
-                            markdownShortcutPlugin(),
-                            tablePlugin(),
-                            diffSourcePlugin({ diffMarkdown: initialMarkdown }),
-                            linkPlugin(),
-                            toolbarPlugin({
-                                toolbarContents: () => (
-                                    <DiffSourceToggleWrapper>
-                                        <UndoRedo />
-                                        <Separator />
-                                        <BoldItalicUnderlineToggles />
-                                        <Separator />
-                                        <BlockTypeSelect />
-                                        <Separator />
-                                        <ListsToggle />
-                                        <Separator />
-                                        <InsertTable />
-                                    </DiffSourceToggleWrapper>
-                                )
-                            }),
-                            catchAllPlugin(),
-                        ]}
-                        ref={editorRef}
-                        onChange={handleChange}
-                        contentEditableClassName="mdxEditor"
-                    />
-                </Card>
-            </Suspense>
-            <FormHelperText>Use this editor to add rich text to your notebook.</FormHelperText>
-        </Grid>
+        <Suspense fallback={<div>Loading...</div>}>
+            {errorMessage &&
+                <Alert onClose={() => { setErrorMessage('') }} severity="error">
+                    {errorMessage}
+                </Alert>
+            }
+            <Card variant="outlined">
+                <MDXEditor
+                    placeholder="Start typing..."
+                    markdown={initialMarkdown}
+                    plugins={[
+                        headingsPlugin(),
+                        listsPlugin(),
+                        quotePlugin(),
+                        thematicBreakPlugin(),
+                        markdownShortcutPlugin(),
+                        tablePlugin(),
+                        diffSourcePlugin({ diffMarkdown: initialMarkdown }),
+                        linkPlugin(),
+                        toolbarPlugin({
+                            toolbarContents: () => (
+                                <DiffSourceToggleWrapper>
+                                    <UndoRedo />
+                                    <Separator />
+                                    <BoldItalicUnderlineToggles />
+                                    <Separator />
+                                    <BlockTypeSelect />
+                                    <Separator />
+                                    <ListsToggle />
+                                    <Separator />
+                                    <InsertTable />
+                                </DiffSourceToggleWrapper>
+                            )
+                        }),
+                        catchAllPlugin(),
+                    ]}
+                    ref={editorRef}
+                    onChange={handleChange}
+                    contentEditableClassName="mdxEditor"
+                />
+            </Card>
+        </Suspense>
     )
 }


### PR DESCRIPTION
# Issue #25 
This PR fixes the above mentioned issue.

## Summary

Fixing the bug required deleting the selected form from the `untickedForms` array. Of course, having fixed that, I noticed that when a form is deleted, the tab index does not always jump as expected (at least, to me). Following are 3 scenarios I have handled.

### Scenario 1

#### Context
- Multiple visible (green) forms
- One or more unticked (orange) forms

#### Expected Behaviour (see video)
- When deleting the last green form, the tab index jumps one back. It does not jump to the orange forms, maintaining that they are separate sets of forms. 

https://github.com/FAIMS/FAIMS3-Designer/assets/100062745/f8e3ea95-1927-4a5e-823e-c979c9d429e4


### Scenario 2 (reverse of Scenario 1)

#### Context
- One or more green forms
- Multiple unticked (orange) forms

#### Expected Behaviour (see video)
- When deleting the last orange form, the tab index jumps one back. It does not jump to the "+" tab. 

https://github.com/FAIMS/FAIMS3-Designer/assets/100062745/bc8a36ea-4a29-4c3a-9433-7a996602627c


### Scenario 3

#### Context
- One green form
- One or more orange forms

#### Expected Behaviour (see video)
- When deleting the last remaining green form, the tab index jumps to the "+" tab. Again, this is to maintain the idea that the orange forms are a separate set. As there are no more green forms, the user is guided to the "+" tab where they can create a new green form.

https://github.com/FAIMS/FAIMS3-Designer/assets/100062745/11532a50-be40-46dc-bde6-1d00701ae6fb


(_Extra_: I have removed FormHelperText from the reusable MdxEditor component as this is actually dynamic. While this could have been passed down as a prop, I didn't think that would be the cleanest solution since some helper text can be long (e.g., info-panel.tsx).) 