### PR TITLE
Image support in MDXEditor

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@emotion/react": "^11.11.1",
         "@emotion/styled": "^11.11.0",
         "@lexical/react": "^0.12.4",
-        "@mdxeditor/editor": "^1.13.0",
+        "@mdxeditor/editor": "^1.13.5",
         "@mui/icons-material": "^5.14.3",
         "@mui/lab": "^5.0.0-alpha.137",
         "@mui/material": "^5.14.2",
@@ -1402,9 +1402,9 @@
       }
     },
     "node_modules/@mdxeditor/editor": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/@mdxeditor/editor/-/editor-1.13.0.tgz",
-      "integrity": "sha512-WKEg+WYVtH+zcoJHzyXXtLV2qQ6cdo+nDJ508Yq7n1XU2GMsmlObVUNd9NqLi3FNa0JRUMEgybHR8eaYAqcyiA==",
+      "version": "1.13.5",
+      "resolved": "https://registry.npmjs.org/@mdxeditor/editor/-/editor-1.13.5.tgz",
+      "integrity": "sha512-KZIzxBRK78aVdWqZUB7jC4B+nFFkVMbOyHga2GQUlLC/44qxA3JwtcpqIS80l30KpOVHQUulPpnSm9XqOdyvRQ==",
       "dependencies": {
         "@codemirror/lang-markdown": "^6.2.1",
         "@codemirror/merge": "^6.1.3",
@@ -1462,6 +1462,11 @@
         "react": "^18.2.0",
         "react-dom": "^18.2.0"
       }
+    },
+    "node_modules/@mdxeditor/editor/node_modules/@radix-ui/colors": {
+      "version": "0.1.9",
+      "resolved": "https://registry.npmjs.org/@radix-ui/colors/-/colors-0.1.9.tgz",
+      "integrity": "sha512-Vxq944ErPJsdVepjEUhOLO9ApUVOocA63knc+V2TkJ09D/AVOjiMIgkca/7VoYgODcla0qbSIBjje0SMfZMbAw=="
     },
     "node_modules/@mui/base": {
       "version": "5.0.0-beta.8",
@@ -1827,11 +1832,6 @@
       "engines": {
         "node": ">=16.3.0"
       }
-    },
-    "node_modules/@radix-ui/colors": {
-      "version": "0.1.9",
-      "resolved": "https://registry.npmjs.org/@radix-ui/colors/-/colors-0.1.9.tgz",
-      "integrity": "sha512-Vxq944ErPJsdVepjEUhOLO9ApUVOocA63knc+V2TkJ09D/AVOjiMIgkca/7VoYgODcla0qbSIBjje0SMfZMbAw=="
     },
     "node_modules/@radix-ui/number": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "@emotion/react": "^11.11.1",
     "@emotion/styled": "^11.11.0",
     "@lexical/react": "^0.12.4",
-    "@mdxeditor/editor": "^1.13.0",
+    "@mdxeditor/editor": "^1.13.5",
     "@mui/icons-material": "^5.14.3",
     "@mui/lab": "^5.0.0-alpha.137",
     "@mui/material": "^5.14.2",

--- a/src/App.css
+++ b/src/App.css
@@ -11,3 +11,42 @@
 .mdxEditor {
   font-family: 'Open Sans', sans-serif;
 }
+
+.image-dialog>div:first-child[aria-hidden="true"] {
+  opacity: 1;
+  background-color: rgba(0, 0, 0, 0.5);
+}
+
+.image-dialog>div:nth-child(2) {
+  box-shadow: 0px 11px 15px -7px rgba(0, 0, 0, 0.2), 0px 24px 38px 3px rgba(0, 0, 0, 0.14), 0px 9px 46px 8px rgba(0, 0, 0, 0.12);
+}
+
+.image-dialog>div:nth-child(2)>form {
+  font-family: 'Open Sans', sans-serif !important;
+}
+
+.image-dialog>div:nth-child(2)>form>div:first-child>label {
+  font-family: 'Open Sans', sans-serif;
+  font-weight: 500;
+  font-size: 1.25rem;
+  line-height: 1.6;
+  color: #263238;
+}
+
+.image-dialog>div:nth-child(2)>form>div:nth-child(5)>button {
+  cursor: pointer;
+  user-select: none;
+  color: #669911;
+  font-family: 'Open Sans',sans-serif;
+  font-weight: 500;
+  font-size: 0.875rem;
+  line-height: 1.75;
+  text-transform: uppercase;
+  background-color: transparent;
+  border-color: transparent;
+  border-radius: 4px;
+}
+
+.image-dialog>div:nth-child(2)>form>div:nth-child(5)>button:hover {
+  background-color: rgba(102, 153, 17, 0.04);
+}

--- a/src/components/mdx-editor.tsx
+++ b/src/components/mdx-editor.tsx
@@ -29,6 +29,7 @@ import { markdownShortcutPlugin } from '@mdxeditor/editor/plugins/markdown-short
 import { tablePlugin } from '@mdxeditor/editor/plugins/table';
 import { diffSourcePlugin } from '@mdxeditor/editor/plugins/diff-source';
 import { linkPlugin } from '@mdxeditor/editor/plugins/link';
+import { imagePlugin } from '@mdxeditor/editor/plugins/image';
 
 // importing the desired toolbar toggle components
 import { UndoRedo } from '@mdxeditor/editor/plugins/toolbar/components/UndoRedo';
@@ -37,6 +38,7 @@ import { BlockTypeSelect } from '@mdxeditor/editor/plugins/toolbar/components/Bl
 import { ListsToggle } from '@mdxeditor/editor/plugins/toolbar/components/ListsToggle';
 import { InsertTable } from '@mdxeditor/editor/plugins/toolbar/components/InsertTable';
 import { DiffSourceToggleWrapper } from '@mdxeditor/editor/plugins/toolbar/components/DiffSourceToggleWrapper';
+import { InsertImage } from '@mdxeditor/editor/plugins/toolbar/components/InsertImage';
 
 
 type Props = {
@@ -72,6 +74,17 @@ export const MdxEditor = ({ initialMarkdown, editorRef, handleChange }: Props) =
         }
     });
 
+    const imageUploadHandler = (image: File): Promise<string> => {
+        return new Promise((resolve) => {
+            const reader = new FileReader();
+            reader.onload = () => {
+                resolve(reader.result as string)
+            }
+            reader.readAsDataURL(image);
+        })
+    }
+
+
     return (
         <Suspense fallback={<div>Loading...</div>}>
             {errorMessage &&
@@ -92,6 +105,7 @@ export const MdxEditor = ({ initialMarkdown, editorRef, handleChange }: Props) =
                         tablePlugin(),
                         diffSourcePlugin({ diffMarkdown: initialMarkdown }),
                         linkPlugin(),
+                        imagePlugin({ imageUploadHandler }),
                         toolbarPlugin({
                             toolbarContents: () => (
                                 <DiffSourceToggleWrapper>
@@ -104,6 +118,8 @@ export const MdxEditor = ({ initialMarkdown, editorRef, handleChange }: Props) =
                                     <ListsToggle />
                                     <Separator />
                                     <InsertTable />
+                                    <Separator />
+                                    <InsertImage />
                                 </DiffSourceToggleWrapper>
                             )
                         }),

--- a/src/components/mdx-editor.tsx
+++ b/src/components/mdx-editor.tsx
@@ -94,6 +94,7 @@ export const MdxEditor = ({ initialMarkdown, editorRef, handleChange }: Props) =
             }
             <Card variant="outlined">
                 <MDXEditor
+                    className="image-dialog"
                     placeholder="Start typing..."
                     markdown={initialMarkdown}
                     plugins={[


### PR DESCRIPTION
# Issue #38 
This PR adds support for inserting images in the MDXEditor boxes used in the 'Info' panel and RichText field. Images can be added by choosing a file in the dialog popup after clicking the 'Insert Image' toolbar button, or by writing markdown in the source.